### PR TITLE
Replace SARIF output with --error flag for simpler semgrep failure handling

### DIFF
--- a/linters/semgrep/action.yml
+++ b/linters/semgrep/action.yml
@@ -55,30 +55,4 @@ runs:
       if: ${{ steps.check.outputs.continue == 'true' }}
       env:
         GITHUB_TOKEN: ${{ inputs.github-token }}
-      run: semgrep scan --config=auto --severity=ERROR --sarif-output=semgrep.sarif .
-
-    - name: Check for Semgrep findings
-      shell: bash
-      if: ${{ steps.check.outputs.continue == 'true' }}
-      env:
-        GITHUB_TOKEN: ${{ inputs.github-token }}
-      run: |
-        if [ ! -f "semgrep.sarif" ]; then
-          echo "No SARIF file found"
-          exit 0
-        fi
-
-        FINDINGS_COUNT=$(jq '[.runs[].results[]] | length' semgrep.sarif)
-
-        if [ "$FINDINGS_COUNT" -gt 0 ]; then
-          exit 1
-        fi
-
-    # https://github.com/github/codeql-action
-    - name: Upload SARIF to GitHub Security
-      uses: github/codeql-action/upload-sarif@v4
-      if: ${{ steps.check.outputs.continue == 'true' && always() }}
-      continue-on-error: true
-      with:
-        sarif_file: semgrep.sarif
-        category: semgrep
+      run: semgrep scan --config=auto --severity=ERROR --error .


### PR DESCRIPTION
# Summary

Simplify the semgrep linter action by using semgrep's native `--error` flag instead of manually parsing SARIF output to detect findings. This removes the separate step that checked for findings in the SARIF file and eliminates the SARIF upload to GitHub Security, resulting in a more streamlined workflow that exits with an error code directly when semgrep finds issues.

## Types of changes

<!--
What types of changes does your code introduce? Put an `x` in the boxes that apply (no space around the brackets).
-->

- [ ] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [x] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [ ] Build or security update (updates dependencies, libraries, or security patches)
- [ ] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

<!--
Put an `x` in the boxes that apply (no space around the brackets). This is simply a reminder of what we are going to look for before merging your code.
-->

- [ ] Unit tests added to validate my fix/feature
- [ ] I have manually tested my change
- [ ] I did not add automation test. Why ?:
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] `readme.md` includes sections on introduction, installation, usage, and contributing
- [ ] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified

## Further comments (if required)

<!--
Add comments here if breaking changes, complex database migration or reprocessing of existing data are required.

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
