### PR TITLE
Remove default value for python-architecture input

### DIFF
--- a/setup/action.yml
+++ b/setup/action.yml
@@ -240,7 +240,6 @@ inputs:
   python-architecture:
     description: 'The target architecture (x86, x64) of the Python interpreter.'
     required: false
-    default: 'x64'
   python-check-latest:
     description: "Set this option if you want the action to check for the latest available version that satisfies the version spec."
     required: false


### PR DESCRIPTION
## Summary

Remove the hardcoded default value for the `python-architecture` input parameter in the setup action.

**Key changes:**
- Remove `default: 'x64'` from the `python-architecture` input in `setup/action.yml`

## Types of changes

- [ ] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [x] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [ ] Build or security update (updates dependencies, libraries, or security patches)
- [ ] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

- [ ] Unit tests added to validate my fix/feature
- [ ] I have manually tested my change
- [ ] I did not add automation test. Why ?:
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] `readme.md` includes sections on introduction, installation, usage, and contributing
- [ ] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified
