### PR TITLE
Pin eslint to v8.57.0 to maintain compatibility with legacy frontend JS

### DIFF
--- a/linters/eslint/action.yml
+++ b/linters/eslint/action.yml
@@ -48,7 +48,7 @@ runs:
       env:
         GITHUB_TOKEN: ${{ inputs.github-token }}
       if: ${{ steps.check.outputs.continue == 'true' }}
-      run: npm install eslint@latest  # Intentionally using latest
+      run: npm install eslint@8.57.0  # Pinned to v8.x - v9 is incompatible with legacy frontend JS (jQuery, etc.)
 
     # https://github.com/marketplace/actions/run-eslint-with-reviewdog
     - name: Run ESLint with Reviewdog


### PR DESCRIPTION
## Summary

This change pins the eslint version to 8.57.0 instead of using `@latest` to ensure compatibility with legacy frontend JavaScript code that uses jQuery and similar libraries.

**Key changes:**
- Pin eslint installation to version 8.57.0 in the eslint linter action, as eslint v9 introduced breaking changes incompatible with legacy frontend JS patterns

## Types of changes

<!--
What types of changes does your code introduce? Put an `x` in the boxes that apply (no space around the brackets).
-->

- [x] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [ ] Build or security update (updates dependencies, libraries, or security patches)
- [ ] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

<!--
Put an `x` in the boxes that apply (no space around the brackets). This is simply a reminder of what we are going to look for before merging your code.
-->

- [ ] Unit tests added to validate my fix/feature
- [x] I have manually tested my change
- [x] I did not add automation test. Why ?: Version pinning change - no new logic to test
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] `readme.md` includes sections on introduction, installation, usage, and contributing
- [ ] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified
