### PR TITLE
Update markdownlint config and fix architecture documentation

### DIFF
--- a/.markdownlint.yml
+++ b/.markdownlint.yml
@@ -4,3 +4,6 @@ line-length: false
 no-duplicate-heading: false
 single-h1: false
 tables: false
+no-inline-html:
+  allowed_elements:
+    - br

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -303,8 +303,9 @@ commit messages and repository state.
 **Algorithm:**
 
 1. Parse `GITHUB_REF` to determine if building a tag, PR, or branch
-2. Compute `BUILD_NAME` and `BUILD_VERSION` with format:
-   `{ref}-{short_commit}-{timestamp}-{run_number}`
+2. Compute `BUILD_NAME` with format:
+   `{ref}-{short_commit}-{timestamp}-{modified_run_number}` and `BUILD_VERSION`
+   with format: `{ref}-{modified_run_number}-{timestamp}`
 3. Extract commit message (tag annotation or git log)
 4. Parse commit message for trigger keywords (`#beta-deploy`, `#skip-linters`, etc.)
 5. Detect enabled linters by checking for configuration files in the repository
@@ -322,7 +323,7 @@ commit messages and repository state.
 1. Create deployment via AWS CLI
 2. Poll deployment status every 5 seconds
 3. Exit on terminal states: Succeeded, Failed, Stopped, Ready
-4. Timeout after 120 iterations (~10 minutes)
+4. Timeout after 119 iterations (~10 minutes)
 
 **Complexity:** O(1) bounded by iteration limit
 


### PR DESCRIPTION
## Summary

Update markdownlint configuration to allow inline HTML `<br>` elements and correct the architecture documentation to accurately reflect the build variable formats and deployment timeout.

**Key changes:**

- Add `no-inline-html` rule to `.markdownlint.yml` with `br` as an allowed element
- Update `docs/architecture.md` to separate `BUILD_NAME` and `BUILD_VERSION` format descriptions, correcting the version format to `{ref}-{modified_run_number}-{timestamp}`
- Fix deployment timeout iteration count from 120 to 119 in architecture docs

## Types of changes

- [ ] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [ ] Build or security update (updates dependencies, libraries, or security patches)
- [x] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

- [ ] Unit tests added to validate my fix/feature
- [ ] I have manually tested my change
- [x] I did not add automation test. Why ?: Documentation and config-only changes, no testable logic
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] `readme.md` includes sections on introduction, installation, usage, and contributing
- [x] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified
