### PR TITLE
Update documentation with fixed links, CIS section, and Slack description

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,9 +84,9 @@ When you submit code changes, your submissions are understood to be under the sa
 
 ## Debugging
 
-Please refer to the [Github Enabling debug logging guide](https://docs.github.com/en/github-ae@latest/actions/monitoring-and-troubleshooting-workflows/enabling-debug-logging)
+Please refer to the [Github Enabling debug logging guide](https://docs.github.com/en/actions/monitoring-and-troubleshooting-workflows/enabling-debug-logging)
 to set secrets to enable runner and steps debug logs.
 
 You can always enable a tmate debug session to connect to a running runner instance and try things manually if debug logs are not enough. See [Debug your GitHub Actions by using tmate](https://github.com/mxschmitt/action-tmate).
 
-The documentation for all the [runner environments](https://github.com/actions/virtual-environments/tree/main/images).
+The documentation for all the [runner environments](https://github.com/actions/runner-images/tree/main/images).

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -69,6 +69,16 @@ workflows.
 - `aws-access-key-id`, `aws-secret-access-key`, `aws-region`: AWS credentials
 - `shell-commands`: Commands to execute
 
+### cis
+
+**Purpose:** CIS (Center for Internet Security) benchmark compliance resource.
+
+**Location:** `cis/`
+
+**Key Components:**
+
+- `PolicyBanner.rtf`: Login policy banner for CIS benchmark compliance
+
 ### codedeploy
 
 **Purpose:** AWS CodeDeploy operations including checkout, S3 copy, and deployment.
@@ -368,7 +378,7 @@ commit messages and repository state.
 | Component | Error Handling |
 | :--- | :--- |
 | CodeDeploy | Status polling with timeout, explicit failure states |
-| Slack | Axios catch block with error logging |
+| Slack | Promise rejection handler with core.setFailed |
 | Linters | Early exit if not enabled, reviewdog for PR comments |
 | Setup | Conditional step execution based on inputs |
 


### PR DESCRIPTION
## Summary

Update README and architecture documentation to fix outdated links and improve accuracy of component descriptions.

**Key changes:**
- Fix GitHub debug logging guide URL to use current docs path instead of deprecated `github-ae@latest` path in `README.md`
- Update runner environments repository link from `actions/virtual-environments` to `actions/runner-images` in `README.md`
- Add `cis` component section documenting the CIS benchmark compliance resource and PolicyBanner in `docs/architecture.md`
- Update Slack error handling description from "Axios catch block with error logging" to "Promise rejection handler with core.setFailed" in `docs/architecture.md`

## Types of changes

- [ ] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [ ] Build or security update (updates dependencies, libraries, or security patches)
- [x] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

- [ ] Unit tests added to validate my fix/feature
- [x] I have manually tested my change
- [x] I did not add automation test. Why ?: Documentation-only changes, no code logic to test
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [x] `readme.md` includes sections on introduction, installation, usage, and contributing
- [x] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified
