### PR TITLE
Silence all checkov console output, rely on SARIF file for reviewdog

### DIFF
--- a/linters/checkov/action.yml
+++ b/linters/checkov/action.yml
@@ -58,7 +58,7 @@ runs:
         REVIEWDOG_GITHUB_API_TOKEN: ${{ inputs.github-token }}
       if: ${{ steps.check.outputs.continue == 'true' }}
       run: |
-        checkov -d . -o sarif --output-file-path /tmp/checkov --quiet --compact --soft-fail 2>/dev/null || true
+        checkov -d . -o sarif --output-file-path /tmp/checkov --soft-fail > /dev/null 2>&1 || true
         if [ -f /tmp/checkov/results_sarif.sarif ]; then
           jq '.version = (.version | tostring)' /tmp/checkov/results_sarif.sarif | reviewdog -f=sarif -name=checkov -reporter=github-pr-review -filter-mode=nofilter -fail-level=any -level=info
         fi


### PR DESCRIPTION
## Summary

Follow-up to #140. The `--quiet --compact` flags did not work as expected with checkov's `-o sarif --output-file-path` mode. Checkov still dumps all human-readable results (passed + failed checks, ASCII banner) AND raw SARIF JSON lines to stdout, even when writing to a file.

**Key changes:**
- Replace `--quiet --compact 2>/dev/null` with `> /dev/null 2>&1` to silence all checkov console output
- Since results are read from the SARIF file (`/tmp/checkov/results_sarif.sarif`), only reviewdog output appears on screen

## Types of changes

- [x] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [ ] Build or security update (updates dependencies, libraries, or security patches)
- [ ] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

- [ ] Unit tests added to validate my fix/feature
- [x] I have manually tested my change
- [x] I did not add automation test. Why ?: CLI flag change only, no testable logic
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] `readme.md` includes sections on introduction, installation, usage, and contributing
- [ ] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified