### PR TITLE
Update slack dependencies and fix deployment iteration count in docs

### DIFF
--- a/.soup.json
+++ b/.soup.json
@@ -266,7 +266,7 @@
   "hasown": {
     "language": "JS",
     "package": "hasown",
-    "version": "2.0.2",
+    "version": "2.0.3",
     "license": "MIT",
     "description": "A robust, ES3 compatible, \"has own property\" predicate.",
     "website": "https://github.com/inspect-js/hasOwn#readme",

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -95,7 +95,7 @@ workflows.
 
 - AWS credential configuration
 - S3 sync operations
-- Deployment creation with status polling (5-second intervals, 119 iterations max)
+- Deployment creation with status polling (5-second intervals, 120 iterations max)
 
 ### docker
 
@@ -325,7 +325,7 @@ commit messages and repository state.
 1. Create deployment via AWS CLI
 2. Poll deployment status every 5 seconds
 3. Exit on terminal states: Succeeded, Failed, Stopped, Ready
-4. Timeout after 119 iterations (~10 minutes)
+4. Timeout after 120 iterations (~10 minutes)
 
 **Complexity:** O(1) bounded by iteration limit
 

--- a/docs/soup.md
+++ b/docs/soup.md
@@ -24,7 +24,7 @@
 | JS | gopd | 1.2.0 | MIT | `Object.getOwnPropertyDescriptor`, but accounts for IE's broken implementation. | <https://github.com/ljharb/gopd#readme> | 2025-09-15 | Low | Dependency | Dependency |
 | JS | has-symbols | 1.1.0 | MIT | Determine if the JS environment has Symbol support. Supports spec, or shams. | <https://github.com/ljharb/has-symbols#readme> | 2025-09-15 | Low | Dependency | Dependency |
 | JS | has-tostringtag | 1.0.2 | MIT | Determine if the JS environment has `Symbol.toStringTag` support. Supports spec, or shams. | <https://github.com/inspect-js/has-tostringtag#readme> | 2025-09-15 | Low | Dependency | Dependency |
-| JS | hasown | 2.0.2 | MIT | A robust, ES3 compatible, "has own property" predicate. | <https://github.com/inspect-js/hasOwn#readme> | 2025-09-15 | Low | Dependency | Dependency |
+| JS | hasown | 2.0.3 | MIT | A robust, ES3 compatible, "has own property" predicate. | <https://github.com/inspect-js/hasOwn#readme> | 2025-09-15 | Low | Dependency | Dependency |
 | JS | math-intrinsics | 1.1.0 | MIT | ES Math-related intrinsics and helpers, robustly cached. | <https://github.com/es-shims/math-intrinsics#readme> | 2025-09-15 | Low | Dependency | Dependency |
 | JS | mime-db | 1.52.0 | MIT | Media Type Database | <https://github.com/jshttp/mime-db#readme> | 2025-09-15 | Low | Dependency | Dependency |
 | JS | mime-types | 2.1.35 | MIT | The ultimate javascript content-type utility. | <https://github.com/jshttp/mime-types#readme> | 2025-09-15 | Low | Dependency | Dependency |

--- a/slack/package-lock.json
+++ b/slack/package-lock.json
@@ -549,9 +549,9 @@
       "license": "MIT"
     },
     "node_modules/@emnapi/core": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.2.tgz",
-      "integrity": "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -561,9 +561,9 @@
       }
     },
     "node_modules/@emnapi/runtime": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
-      "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -2132,9 +2132,9 @@
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.336",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.336.tgz",
-      "integrity": "sha512-AbH9q9J455r/nLmdNZes0G0ZKcRX73FicwowalLs6ijwOmCJSRRrLX63lcAlzy9ux3dWK1w1+1nsBJEWN11hcQ==",
+      "version": "1.5.340",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.340.tgz",
+      "integrity": "sha512-908qahOGocRMinT2nM3ajCEM99H4iPdv84eagPP3FfZy/1ZGeOy2CZYzjhms81ckOPCXPlW7LkY4XpxD8r1DrA==",
       "dev": true,
       "license": "ISC"
     },
@@ -2580,9 +2580,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"


### PR DESCRIPTION
# Summary

Update minor/patch slack dependencies and correct the deployment polling iteration count in architecture documentation.

**Key changes:**
- Update `@emnapi/core` from 1.9.2 to 1.10.0 and `@emnapi/runtime` from 1.9.2 to 1.10.0
- Update `electron-to-chromium` from 1.5.336 to 1.5.340
- Update `hasown` from 2.0.2 to 2.0.3
- Fix deployment polling iteration count from 119 to 120 in `docs/architecture.md` (two occurrences)

## Types of changes

- [ ] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [x] Build or security update (updates dependencies, libraries, or security patches)
- [x] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

- [ ] Unit tests added to validate my fix/feature
- [ ] I have manually tested my change
- [x] I did not add automation test. Why ?: Dependency lock file update and documentation fix only
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] `readme.md` includes sections on introduction, installation, usage, and contributing
- [x] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified
