### PR TITLE
Remove auto-merge step and update baseline-browser-mapping

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -77,10 +77,3 @@ jobs:
       env:
         GH_TOKEN: "${{secrets.GITHUB_TOKEN}}"
         PR: "${{github.event.pull_request.number}}"
-    - name: Enable auto-merge
-      shell: bash
-      if: steps.check.outputs.is_owner == 'true'
-      run: gh pr merge --auto --squash "$PR"
-      env:
-        GH_TOKEN: "${{secrets.GITHUB_TOKEN}}"
-        PR: "${{github.event.pull_request.number}}"

--- a/slack/package-lock.json
+++ b/slack/package-lock.json
@@ -1714,9 +1714,9 @@
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.23",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.23.tgz",
-      "integrity": "sha512-xwVXGqevyKPsiuQdLj+dZMVjidjJV508TBqexND5HrF89cGdCYCJFB3qhcxRHSeMctdCfbR1jrxBajhDy7o29g==",
+      "version": "2.10.24",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.24.tgz",
+      "integrity": "sha512-I2NkZOOrj2XuguvWCK6OVh9GavsNjZjK908Rq3mIBK25+GD8vPX5w2WdxVqnQ7xx3SrZJiCiZFu+/Oz50oSYSA==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {


### PR DESCRIPTION
## Summary

Removes the auto-merge enabling step from the auto-merge workflow and bumps a transitive dev dependency in the slack package lockfile.

**Key changes:**

- Remove the "Enable auto-merge" step from `.github/workflows/auto-merge.yml` so the workflow no longer calls `gh pr merge --auto --squash` after the ownership check.
- Update `baseline-browser-mapping` from `2.10.23` to `2.10.24` in `slack/package-lock.json`.

## Types of changes

- [ ] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [x] Build or security update (updates dependencies, libraries, or security patches)
- [ ] Code style or documentation update (formatting, renaming, or documentation changes)
- [x] Other (please describe): Workflow change — removes the auto-merge enabling step from the reusable auto-merge workflow.

## Checklist

- [ ] Unit tests added to validate my fix/feature
- [x] I have manually tested my change
- [x] I did not add automation test. Why ?: Workflow YAML and lockfile change; no test surface.
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] `readme.md` includes sections on introduction, installation, usage, and contributing
- [ ] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified

Note: per project memory, this should land via a feature branch + PR rather than a direct push to `master`.
