### PR TITLE
Pre-register GITHUB_TOKEN with composer auth in phpstan action

### DIFF
--- a/linters/phpstan/action.yml
+++ b/linters/phpstan/action.yml
@@ -105,7 +105,9 @@ runs:
       env:
         GITHUB_TOKEN: ${{ inputs.github-token }}
         COMPOSER_COMMAND: ${{ inputs.composer-command }}
-      run: eval "${COMPOSER_COMMAND}"
+      run: |
+        composer config --global --auth github-oauth.github.com "${GITHUB_TOKEN}"
+        eval "${COMPOSER_COMMAND}"
 
     # https://phpstan.org/
     - name: Run PHPStan


### PR DESCRIPTION
## Summary

The `phpstan` action passes `GITHUB_TOKEN` as an env var to its `Run Composer` step but never registers it with composer's auth config. Composer doesn't auto-read `GITHUB_TOKEN`, so all `https://api.github.com/...` dist downloads return `Could not authenticate against github.com`. The parent `composer install` limps through via source clone (over the loaded `ssh-agent`), but bamarni-bin nested installs (e.g. pnp-api's `sbin/phpstan/composer.json`) abort on the first auth error — leaving `vendor/bin/phpstan` uninstalled and the linter step exiting 127. Reproduced on two consecutive pnp-api PR runs (jobs `73621661132` and `73646184188`); identical logs, not transient.

**Key changes:**

- `linters/phpstan/action.yml`: in the `Run Composer` step, run `composer config --global --auth github-oauth.github.com "${GITHUB_TOKEN}"` before `eval "${COMPOSER_COMMAND}"` so the token is written to `$COMPOSER_HOME/auth.json` and inherited by both the parent install and any bamarni-bin nested installs.

## Types of changes

- [x] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [ ] Build or security update (updates dependencies, libraries, or security patches)
- [ ] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

- [ ] Unit tests added to validate my fix/feature
- [ ] I have manually tested my change
- [x] I did not add automation test. Why ?: ci-actions are composite GitHub Actions with no unit-test harness in this repo; verification is done by re-running the consumer workflow (pnp-api PR #5287 PHPStan job) after merge.
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] `readme.md` includes sections on introduction, installation, usage, and contributing
- [ ] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified