### PR TITLE
Remove duplicate external actions list from architecture.md

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -247,51 +247,9 @@ input variable, which is populated by the variables action.
 
 ## Software of Unknown Provenance
 
-See [soup.md](soup.md) for the complete SOUP list.
-
-### External Action Dependencies
-
-The actions depend on the following third-party GitHub Actions (see individual action.yml
-files for current versions):
-
-| Action | Purpose |
-| :--- | :--- |
-| actions/checkout | Repository checkout |
-| actions/setup-go | Go runtime setup |
-| actions/setup-java | Java runtime setup |
-| actions/setup-node | Node.js runtime setup |
-| actions/setup-python | Python runtime setup |
-| actions/cache | Dependency caching |
-| actions/attest-build-provenance | Build attestation |
-| aws-actions/configure-aws-credentials | AWS credential configuration |
-| docker/login-action | Docker registry login |
-| docker/setup-buildx-action | Docker Buildx setup |
-| docker/metadata-action | Docker metadata extraction |
-| docker/build-push-action | Docker build and push |
-| ruby/setup-ruby | Ruby runtime setup |
-| shivammathur/setup-php | PHP runtime setup |
-| webfactory/ssh-agent | SSH agent setup |
-| amyu/setup-android | Android SDK setup |
-| maxim-lobanov/setup-xcode | Xcode setup |
-| miyataka/elasticsearch-github-actions | Elasticsearch setup |
-| supercharge/mongodb-github-action | MongoDB setup |
-| shogo82148/actions-setup-mysql | MySQL setup |
-| namoshek/rabbitmq-github-action | RabbitMQ setup |
-| shogo82148/actions-setup-redis | Redis setup |
-| reviewdog/action-eslint | ESLint with reviewdog |
-| reviewdog/action-setup | Reviewdog CLI setup |
-| reviewdog/action-golangci-lint | Go linting with reviewdog |
-| reviewdog/action-yamllint | YAML linting with reviewdog |
-| reviewdog/action-shellcheck | Shell script linting with reviewdog |
-| reviewdog/action-hadolint | Dockerfile linting with reviewdog |
-| reviewdog/action-rubocop | Ruby linting with reviewdog |
-| reviewdog/action-actionlint | GitHub Actions linting with reviewdog |
-| yoheimuta/action-protolint | Protocol Buffers linting |
-| ScaCap/action-ktlint | Kotlin linting |
-| norio-nomura/action-swiftlint | Swift linting |
-| tj-actions/bandit | Python security linter |
-| aquasecurity/trivy-action | Container & IaC vulnerability scanner |
-| ScottBrenner/cfn-lint-action | AWS CloudFormation linter |
+See [soup.md](soup.md) for the complete list of third-party dependencies. Third-party
+GitHub Actions referenced by composite actions are declared in their respective
+`action.yml` files.
 
 ## Critical algorithms
 


### PR DESCRIPTION
## Summary

Removes the redundant "External Action Dependencies" table from `docs/architecture.md`. The same information is already maintained in `soup.md` and in the individual `action.yml` files, so this duplicated list was a maintenance burden that drifted out of sync over time.

**Key changes:**
- Drop the 30+ row table of third-party GitHub Actions from `docs/architecture.md`
- Replace it with a short note pointing readers to `soup.md` and the per-action `action.yml` files as the source of truth

## Types of changes

- [ ] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [ ] Build or security update (updates dependencies, libraries, or security patches)
- [x] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

- [ ] Unit tests added to validate my fix/feature
- [x] I have manually tested my change
- [ ] I did not add automation test. Why ?:
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] `readme.md` includes sections on introduction, installation, usage, and contributing
- [x] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified