### PR TITLE
Update build Node to 26.1.0 and bump slack @types/node to 25.6.2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ permissions:
   contents: read
   pull-requests: read
 env:
-  NODE-VERSION: 25.9.0
+  NODE-VERSION: 26.1.0
 jobs:
   variables:
     name: Prepare Variables

--- a/.gitignore
+++ b/.gitignore
@@ -514,7 +514,6 @@ $RECYCLE.BIN/
 # Windows shortcuts
 *.lnk
 
-docs/code-review.md
 # End of https://www.toptal.com/developers/gitignore/api/eclipse,emacs,jetbrains,linux,macos,netbeans,nova,ruby,sublimetext,vim,visualstudiocode,webstorm,windows
 
 # BEGIN AI Assistants
@@ -539,3 +538,4 @@ coverage/
 
 # GitHub Actions bundled output
 !slack/dist/
+docs/code-review.md

--- a/slack/package-lock.json
+++ b/slack/package-lock.json
@@ -1165,9 +1165,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "25.6.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.1.tgz",
-      "integrity": "sha512-coJCN8O1q4AGyyqCAUSP06P+SrMTu18BkEj3NVAK07q6QUneD2wzj3CLv9+yP+BMeZQlMvneXqqvDe3w+xcq7g==",
+      "version": "25.6.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.2.tgz",
+      "integrity": "sha512-sokuT28dxf9JT5Kady1fsXOvI4HVpjZa95NKT5y9PNTIrs2AsobR4GFAA90ZG8M+nxVRLysCXsVj6eGC7Vbrlw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
## Summary

Routine maintenance update bumping the workflow Node version and a slack action dev dependency, plus a small reorder in `.gitignore` so the `docs/code-review.md` entry sits with the other AI/tooling artifact rules at the bottom of the file.

**Key changes:**

- `.github/workflows/build.yml`: bump `NODE-VERSION` from `25.9.0` to `26.1.0`.
- `slack/package-lock.json`: bump `@types/node` from `25.6.1` to `25.6.2`.
- `.gitignore`: move the `docs/code-review.md` ignore entry out of the toptal-generated block and into the project-specific section at the end of the file.

## Types of changes

- [ ] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [x] Build or security update (updates dependencies, libraries, or security patches)
- [ ] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

- [ ] Unit tests added to validate my fix/feature
- [ ] I have manually tested my change
- [x] I did not add automation test. Why ?: dependency/version bump only — covered by existing CI.
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] `readme.md` includes sections on introduction, installation, usage, and contributing
- [ ] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified