### PR TITLE
Switch CODEOWNERS to team, use bot PAT for auto-merge, bump slack deps

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,15 +1,15 @@
 # https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners
 
-*                        @ydesgagn
+*                        @Cloud-Officer/Maintainers
 
 # build/deploy related files
 
-.eslintrc.json           @ydesgagn
-.github/                 @ydesgagn
-.gitignore               @ydesgagn
-.markdownlint-cli2.yaml  @ydesgagn
-.ruby-version            @ydesgagn
-.shellcheckrc            @ydesgagn
-.yamllint.yml            @ydesgagn
-codedeploy/              @ydesgagn
-*.sh                     @ydesgagn
+.eslintrc.json           @Cloud-Officer/maintainers
+.github/                 @Cloud-Officer/maintainers
+.gitignore               @Cloud-Officer/maintainers
+.markdownlint-cli2.yaml  @Cloud-Officer/maintainers
+.ruby-version            @Cloud-Officer/maintainers
+.shellcheckrc            @Cloud-Officer/maintainers
+.yamllint.yml            @Cloud-Officer/maintainers
+codedeploy/              @Cloud-Officer/maintainers
+*.sh                     @Cloud-Officer/maintainers

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -75,5 +75,5 @@ jobs:
       if: steps.check.outputs.is_owner == 'true'
       run: gh pr review --approve "$PR"
       env:
-        GH_TOKEN: "${{secrets.GITHUB_TOKEN}}"
+        GH_TOKEN: "${{secrets.GH_BOT_PAT}}"
         PR: "${{github.event.pull_request.number}}"

--- a/slack/package-lock.json
+++ b/slack/package-lock.json
@@ -628,17 +628,17 @@
       }
     },
     "node_modules/@jest/console": {
-      "version": "30.4.0",
-      "resolved": "https://registry.npmjs.org/@jest/console/-/console-30.4.0.tgz",
-      "integrity": "sha512-116ay6wMT9l0QRIhmvDtcw77Ql35S0CMePCn5FGIvuqUZv+Twx+hiIacSPH1pONdG7JhiWqOiqX7s2eQ7Wko2g==",
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/@jest/console/-/console-30.4.1.tgz",
+      "integrity": "sha512-v3bhyxUh9Hgmo5p6hAOXe14/R3ZxZDOsvHleh4B07z3m/x4/ngPUXEm9XwK4sF4u+f+P2ORb0Ge+MgpaqRMVDA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/types": "30.4.0",
+        "@jest/types": "30.4.1",
         "@types/node": "*",
         "chalk": "^4.1.2",
-        "jest-message-util": "30.4.0",
-        "jest-util": "30.4.0",
+        "jest-message-util": "30.4.1",
+        "jest-util": "30.4.1",
         "slash": "^3.0.0"
       },
       "engines": {
@@ -646,38 +646,39 @@
       }
     },
     "node_modules/@jest/core": {
-      "version": "30.4.0",
-      "resolved": "https://registry.npmjs.org/@jest/core/-/core-30.4.0.tgz",
-      "integrity": "sha512-447tRaMsRo65u4ByBxHk4XnuNYX7M0vfazqMdPgJTUTttmC4/7A8yzBE6mSKkj2Md+dR3DWF9mVNfF/Bo+cJJg==",
+      "version": "30.4.2",
+      "resolved": "https://registry.npmjs.org/@jest/core/-/core-30.4.2.tgz",
+      "integrity": "sha512-TZJA6cPJUFxoWhxaLo8t0VX/MZX2wPWr0uIDvLSHIvN4gu9h02vSzqI2kBADG1ExqQlC+cY09xKMSreivvrChQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/console": "30.4.0",
+        "@jest/console": "30.4.1",
         "@jest/pattern": "30.4.0",
-        "@jest/reporters": "30.4.0",
-        "@jest/test-result": "30.4.0",
-        "@jest/transform": "30.4.0",
-        "@jest/types": "30.4.0",
+        "@jest/reporters": "30.4.1",
+        "@jest/test-result": "30.4.1",
+        "@jest/transform": "30.4.1",
+        "@jest/types": "30.4.1",
         "@types/node": "*",
         "ansi-escapes": "^4.3.2",
         "chalk": "^4.1.2",
         "ci-info": "^4.2.0",
         "exit-x": "^0.2.2",
+        "fast-json-stable-stringify": "^2.1.0",
         "graceful-fs": "^4.2.11",
-        "jest-changed-files": "30.4.0",
-        "jest-config": "30.4.0",
-        "jest-haste-map": "30.4.0",
-        "jest-message-util": "30.4.0",
+        "jest-changed-files": "30.4.1",
+        "jest-config": "30.4.2",
+        "jest-haste-map": "30.4.1",
+        "jest-message-util": "30.4.1",
         "jest-regex-util": "30.4.0",
-        "jest-resolve": "30.4.0",
-        "jest-resolve-dependencies": "30.4.0",
-        "jest-runner": "30.4.0",
-        "jest-runtime": "30.4.0",
-        "jest-snapshot": "30.4.0",
-        "jest-util": "30.4.0",
-        "jest-validate": "30.4.0",
-        "jest-watcher": "30.4.0",
-        "pretty-format": "30.4.0",
+        "jest-resolve": "30.4.1",
+        "jest-resolve-dependencies": "30.4.2",
+        "jest-runner": "30.4.2",
+        "jest-runtime": "30.4.2",
+        "jest-snapshot": "30.4.1",
+        "jest-util": "30.4.1",
+        "jest-validate": "30.4.1",
+        "jest-watcher": "30.4.1",
+        "pretty-format": "30.4.1",
         "slash": "^3.0.0"
       },
       "engines": {
@@ -703,39 +704,39 @@
       }
     },
     "node_modules/@jest/environment": {
-      "version": "30.4.0",
-      "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-30.4.0.tgz",
-      "integrity": "sha512-X9ba/XraafanjsAXRnbRLydhgH10o0RaQIW1evmT0JJ0ShP2DI0khkt0HVNuPnadxUnl1Y6ihCksuA0btmeh6A==",
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-30.4.1.tgz",
+      "integrity": "sha512-AK9yNRqgKxiabqMoe4oW+3/TSSeV8vkdC7BGaxZdU0AFXfOpofTLqdru2GXKZghP3sdgwE9XXpnVwfZ8JnFV4w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/fake-timers": "30.4.0",
-        "@jest/types": "30.4.0",
+        "@jest/fake-timers": "30.4.1",
+        "@jest/types": "30.4.1",
         "@types/node": "*",
-        "jest-mock": "30.4.0"
+        "jest-mock": "30.4.1"
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "node_modules/@jest/expect": {
-      "version": "30.4.0",
-      "resolved": "https://registry.npmjs.org/@jest/expect/-/expect-30.4.0.tgz",
-      "integrity": "sha512-eJeAOjHMAD1R/vwGQ8DJkD7z7QBj4Fb8T3/tId1srXAx9UJ9zxWVd875WP1dfGmiznMDoalJGZutzi6UR3R6dA==",
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/@jest/expect/-/expect-30.4.1.tgz",
+      "integrity": "sha512-ginrj6TMgh2GshLUGCjO94Ptx9HhdZA/I6A9iUfyeLKFtdAjnKzHDgzgP9HYQgbxM1lbXScQ2eUBz2lGeVDPWA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "expect": "30.4.0",
-        "jest-snapshot": "30.4.0"
+        "expect": "30.4.1",
+        "jest-snapshot": "30.4.1"
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "node_modules/@jest/expect-utils": {
-      "version": "30.4.0",
-      "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-30.4.0.tgz",
-      "integrity": "sha512-+7IjdIwKEvViPvFizspuFeFAJhQGYkbOWBBWq+XVLsSl4t3H6lOk9QlxYC3et6GRgJ+jJvnVOAv2CpN4kJowzQ==",
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-30.4.1.tgz",
+      "integrity": "sha512-ZBn5CglH8fBsQsvs4VWNzD4aWfUYks+IdOOQU3MEK71ol/BcVm+P+rtb1KpiFBpSWSCE27uOahyyf1vfqOVbcQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -746,18 +747,18 @@
       }
     },
     "node_modules/@jest/fake-timers": {
-      "version": "30.4.0",
-      "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-30.4.0.tgz",
-      "integrity": "sha512-J+uX5pz4SYiiMP2gR6wqjygxCBhwYXhdPn07XPmZUFTMvm9TQpIGEt4TLbKCMQszslSe3ElEV6GvX3K1CPtzrQ==",
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-30.4.1.tgz",
+      "integrity": "sha512-iW5umdmfPeWzehrVhugFQZqCchSCud5S1l2YT0O9ZhjRR0ExclANDZkiSBwzqtnlOn0J1JXvO+HZ6rkuyOVOgQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/types": "30.4.0",
+        "@jest/types": "30.4.1",
         "@sinonjs/fake-timers": "^15.4.0",
         "@types/node": "*",
-        "jest-message-util": "30.4.0",
-        "jest-mock": "30.4.0",
-        "jest-util": "30.4.0"
+        "jest-message-util": "30.4.1",
+        "jest-mock": "30.4.1",
+        "jest-util": "30.4.1"
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
@@ -774,16 +775,16 @@
       }
     },
     "node_modules/@jest/globals": {
-      "version": "30.4.0",
-      "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-30.4.0.tgz",
-      "integrity": "sha512-xf3neOb0PXqNgT7bLpNAcQmrDOQ1rv6zsfSYSQsEXnpFIqkJvJ2Qyp+4P8Bl5XXnL3pMmrjtNHRgl34Ou7TGKA==",
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-30.4.1.tgz",
+      "integrity": "sha512-ZbuY4cmXC8DkxYjfvT2DbcHWL2T6vmsMhXCDcmTB2T0y0gaezBI77ufq5ZAIdcRkYZ7NEQEDg1xFeKbxUJ5v5Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/environment": "30.4.0",
-        "@jest/expect": "30.4.0",
-        "@jest/types": "30.4.0",
-        "jest-mock": "30.4.0"
+        "@jest/environment": "30.4.1",
+        "@jest/expect": "30.4.1",
+        "@jest/types": "30.4.1",
+        "jest-mock": "30.4.1"
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
@@ -804,17 +805,17 @@
       }
     },
     "node_modules/@jest/reporters": {
-      "version": "30.4.0",
-      "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-30.4.0.tgz",
-      "integrity": "sha512-GMpW1XRCVWKfaGOthupxLTM0Dk/lvDDu6Bb5CgoSkFhbQ+4OT5BcurzInZ99OLeEM7X71i0zv7JmNYHKkcQhFQ==",
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-30.4.1.tgz",
+      "integrity": "sha512-/SnkPCzEQpUaBH81kjdEdDdo2WZl5hxw+BmLDGWjRkm8o7XlhjwsU36cqwe5PGBE5WYpBvDzRSdXx9rbGuJtNA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@bcoe/v8-coverage": "^0.2.3",
-        "@jest/console": "30.4.0",
-        "@jest/test-result": "30.4.0",
-        "@jest/transform": "30.4.0",
-        "@jest/types": "30.4.0",
+        "@jest/console": "30.4.1",
+        "@jest/test-result": "30.4.1",
+        "@jest/transform": "30.4.1",
+        "@jest/types": "30.4.1",
         "@jridgewell/trace-mapping": "^0.3.25",
         "@types/node": "*",
         "chalk": "^4.1.2",
@@ -827,9 +828,9 @@
         "istanbul-lib-report": "^3.0.0",
         "istanbul-lib-source-maps": "^5.0.0",
         "istanbul-reports": "^3.1.3",
-        "jest-message-util": "30.4.0",
-        "jest-util": "30.4.0",
-        "jest-worker": "30.4.0",
+        "jest-message-util": "30.4.1",
+        "jest-util": "30.4.1",
+        "jest-worker": "30.4.1",
         "slash": "^3.0.0",
         "string-length": "^4.0.2",
         "v8-to-istanbul": "^9.0.1"
@@ -847,9 +848,9 @@
       }
     },
     "node_modules/@jest/schemas": {
-      "version": "30.4.0",
-      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.4.0.tgz",
-      "integrity": "sha512-tJLUhzktAsL7VKYJzdkNKxYTKGnkQvd6bMZQtxWnaE4V1VJyzzwt5WrCG5hwC+mB55uZbNSsxQUXLKjla08XPg==",
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.4.1.tgz",
+      "integrity": "sha512-i6b4qw5qnP8c5FEeBJg/uZQ4ddrkN6Ca8qISJh0pr7a5hfn3h3v5x60BEbOC7OYAGZNMs1LfFLwnW2CuK8F57Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -860,13 +861,13 @@
       }
     },
     "node_modules/@jest/snapshot-utils": {
-      "version": "30.4.0",
-      "resolved": "https://registry.npmjs.org/@jest/snapshot-utils/-/snapshot-utils-30.4.0.tgz",
-      "integrity": "sha512-oPrzffukMros86mvKXzDMiAV5qId0U3dTGV/nLnhsKsUKjma7pwmoOvNA5mprG7hVUJ6raRBqkVZVk+kyyjbpw==",
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/@jest/snapshot-utils/-/snapshot-utils-30.4.1.tgz",
+      "integrity": "sha512-ObY4ljvQ95mt6iwKtVLetR/4yXiAgl3H4nJxhztr0MTjrN97TwDYrnCp/kF60Ec9HdhkWTHSu+Hg05aXfngpOA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/types": "30.4.0",
+        "@jest/types": "30.4.1",
         "chalk": "^4.1.2",
         "graceful-fs": "^4.2.11",
         "natural-compare": "^1.4.0"
@@ -891,14 +892,14 @@
       }
     },
     "node_modules/@jest/test-result": {
-      "version": "30.4.0",
-      "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-30.4.0.tgz",
-      "integrity": "sha512-brA2woQJEP0TyaZ7UEe/8aNvXTYYJ3iuCD3Rm78zNKF2CLqY7ShM+mdJ0f3dvy7ruWE5gKsFvd2bODmeTC8z2Q==",
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-30.4.1.tgz",
+      "integrity": "sha512-/ZG7pgEiOmmWkN9TplKbOu4id2N5lh7FHwRwlkgBVAzGdRH+OkkQ8wX/kIxg4zmd3ZQvAL1RwL2yWsvNYYECTw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/console": "30.4.0",
-        "@jest/types": "30.4.0",
+        "@jest/console": "30.4.1",
+        "@jest/types": "30.4.1",
         "@types/istanbul-lib-coverage": "^2.0.6",
         "collect-v8-coverage": "^1.0.2"
       },
@@ -907,15 +908,15 @@
       }
     },
     "node_modules/@jest/test-sequencer": {
-      "version": "30.4.0",
-      "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-30.4.0.tgz",
-      "integrity": "sha512-6xWCB+Ix4dMqoc987QxF4piGeC1Mzv71NeWlHo8Wa3z3z8Yookz68gYwFJAKQO+SPhduIs2csX71syItuvrg/Q==",
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-30.4.1.tgz",
+      "integrity": "sha512-PeYE+4td5rKjoRPxztObrXU+H8hsjZfxKMXOcmrr34JerSyB/ROOxbbicz8B7A5j9R9VayDnVPvBmedqCsFCdw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/test-result": "30.4.0",
+        "@jest/test-result": "30.4.1",
         "graceful-fs": "^4.2.11",
-        "jest-haste-map": "30.4.0",
+        "jest-haste-map": "30.4.1",
         "slash": "^3.0.0"
       },
       "engines": {
@@ -923,23 +924,23 @@
       }
     },
     "node_modules/@jest/transform": {
-      "version": "30.4.0",
-      "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-30.4.0.tgz",
-      "integrity": "sha512-2X7FL+yezRtfthTZdUgtWnbixqkmGnDfkXE1vimu2Y1Wi7g0WxY2AAPctVrU7J9xmw5dWOBprBjx1hJIamJPbg==",
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-30.4.1.tgz",
+      "integrity": "sha512-Wz0LyktlTvRefoymh+n64hQ84KNXsRGcwdoZ8CSa0Ea+fgYcHZlnk+hDP7v2MS7il2bQ5uTEIxf4/NNfhMN4KQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.27.4",
-        "@jest/types": "30.4.0",
+        "@jest/types": "30.4.1",
         "@jridgewell/trace-mapping": "^0.3.25",
         "babel-plugin-istanbul": "^7.0.1",
         "chalk": "^4.1.2",
         "convert-source-map": "^2.0.0",
         "fast-json-stable-stringify": "^2.1.0",
         "graceful-fs": "^4.2.11",
-        "jest-haste-map": "30.4.0",
+        "jest-haste-map": "30.4.1",
         "jest-regex-util": "30.4.0",
-        "jest-util": "30.4.0",
+        "jest-util": "30.4.1",
         "pirates": "^4.0.7",
         "slash": "^3.0.0",
         "write-file-atomic": "^5.0.1"
@@ -949,14 +950,14 @@
       }
     },
     "node_modules/@jest/types": {
-      "version": "30.4.0",
-      "resolved": "https://registry.npmjs.org/@jest/types/-/types-30.4.0.tgz",
-      "integrity": "sha512-C951KSoEicxFUsUIO4T8lqWEemuMgMb3vlI8FO4OP369GSf6SOJd681nOcv7XR0TV5vCO4Jypvq3rBGEqfy9KQ==",
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-30.4.1.tgz",
+      "integrity": "sha512-f1x/vJXIfjOlEmejYpbkbgw1gOqpPECwMvMEtBqe47j7H2Hg8h8w3o3ikhSXq3MI15kg+oQ0exWO0uCtTNJLoQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jest/pattern": "30.4.0",
-        "@jest/schemas": "30.4.0",
+        "@jest/schemas": "30.4.1",
         "@types/istanbul-lib-coverage": "^2.0.6",
         "@types/istanbul-reports": "^3.0.4",
         "@types/node": "*",
@@ -1608,13 +1609,13 @@
       }
     },
     "node_modules/babel-jest": {
-      "version": "30.4.0",
-      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-30.4.0.tgz",
-      "integrity": "sha512-GQ4CKCr1XQ1dettGyiDCPg2u4kP/nav2z9PugOM3Da5l3zpNzY9PRuxmN1dV714Ghm2fdkQLhNxlUopDcoKc6A==",
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-30.4.1.tgz",
+      "integrity": "sha512-fATAbM8piYxkiXQp3RBXmZHxZVNJZAVXXfyeyCN2Tida3+qJ8ea9UxhiJ2y4fLO90ZImKt6k9FlcH2+rLkJGhw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/transform": "30.4.0",
+        "@jest/transform": "30.4.1",
         "@types/babel__core": "^7.20.5",
         "babel-plugin-istanbul": "^7.0.1",
         "babel-preset-jest": "30.4.0",
@@ -1714,9 +1715,9 @@
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.27",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.27.tgz",
-      "integrity": "sha512-zEs/ufmZoUd7WftKpKyXaT6RFxpQ5Qm9xytKRHvJfxFV9DFJkZph9RvJ1LcOUi0Z1ZVijMte65JbILeV+8QQEA==",
+      "version": "2.10.29",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.29.tgz",
+      "integrity": "sha512-Asa2krT+XTPZINCS+2QcyS8WTkObE77RwkydwF7h6DmnKqbvlalz93m/dnphUyCa6SWSP51VgtEUf2FN+gelFQ==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -2132,9 +2133,9 @@
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.352",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.352.tgz",
-      "integrity": "sha512-9wHk8x6dyuimoe18EdiDPWKExNdxYqo4fn4FwOVVper6RxT3cmpBwBkWWfSOCYJjQdIco/nPhJhNLmn4Ufg1Yg==",
+      "version": "1.5.353",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.353.tgz",
+      "integrity": "sha512-kOrWphBi8TOZyiJZqsgqIle0lw+tzmnQK83pV9dZUd01Nm2POECSyFQMAuarzZdYqQW7FH9RaYOuaRo3h+bQ3w==",
       "dev": true,
       "license": "ISC"
     },
@@ -2289,18 +2290,18 @@
       }
     },
     "node_modules/expect": {
-      "version": "30.4.0",
-      "resolved": "https://registry.npmjs.org/expect/-/expect-30.4.0.tgz",
-      "integrity": "sha512-wwj3yHn8F2Uj4fyL+2n1M1cjfYFGtYq7cF00OjMHBxX5eTeX/EcVdHHIMkhxO6nFfopwHtaQEasP1WfxzQaZPg==",
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/expect/-/expect-30.4.1.tgz",
+      "integrity": "sha512-PMARsyh/JtqC20HoGqlFcIlQAyqUtW4PlI1rup1uhYJtKuwAjbvWi3GQMAn+STdHum/dk8xrKfUM1+5SAwpolA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/expect-utils": "30.4.0",
+        "@jest/expect-utils": "30.4.1",
         "@jest/get-type": "30.1.0",
-        "jest-matcher-utils": "30.4.0",
-        "jest-message-util": "30.4.0",
-        "jest-mock": "30.4.0",
-        "jest-util": "30.4.0"
+        "jest-matcher-utils": "30.4.1",
+        "jest-message-util": "30.4.1",
+        "jest-mock": "30.4.1",
+        "jest-util": "30.4.1"
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
@@ -2732,9 +2733,9 @@
       }
     },
     "node_modules/istanbul-lib-instrument/node_modules/semver": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
+      "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -2805,16 +2806,16 @@
       }
     },
     "node_modules/jest": {
-      "version": "30.4.0",
-      "resolved": "https://registry.npmjs.org/jest/-/jest-30.4.0.tgz",
-      "integrity": "sha512-4+7GP22nzoACtoFiKP9rptEF49oQJs0C/hCk7oW8oEIeSH9j43EiQmJCCPVGWQ1noI98CgKl2TeLwaIJzO2Bvg==",
+      "version": "30.4.2",
+      "resolved": "https://registry.npmjs.org/jest/-/jest-30.4.2.tgz",
+      "integrity": "sha512-Yi1jqNC/Oq0N4hBgNH/YvBpP1P57QqundgytzYqy3yqAa7NZPNjSoi4SGbRAXDMdBzNE6xBCi5U7RgfrvMEUVQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/core": "30.4.0",
-        "@jest/types": "30.4.0",
+        "@jest/core": "30.4.2",
+        "@jest/types": "30.4.1",
         "import-local": "^3.2.0",
-        "jest-cli": "30.4.0"
+        "jest-cli": "30.4.2"
       },
       "bin": {
         "jest": "bin/jest.js"
@@ -2832,14 +2833,14 @@
       }
     },
     "node_modules/jest-changed-files": {
-      "version": "30.4.0",
-      "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-30.4.0.tgz",
-      "integrity": "sha512-L6TnosD7ftCv+r6ENOSoqeKdPA+IG4L+3ayXmmmlzPyEK4aU34KTUJC+Y/ep755LyQfV6DOdhnxXVRTrGJNX5w==",
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-30.4.1.tgz",
+      "integrity": "sha512-IuctmYrxi21iOSOaIXpJWalHyPAsVv0GeBHKDn8C1CA4W5htHn7INL+wdnL4Bo0+olEndvAFkmb++tIQJG+vvg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "execa": "^5.1.1",
-        "jest-util": "30.4.0",
+        "jest-util": "30.4.1",
         "p-limit": "^3.1.0"
       },
       "engines": {
@@ -2847,29 +2848,29 @@
       }
     },
     "node_modules/jest-circus": {
-      "version": "30.4.0",
-      "resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-30.4.0.tgz",
-      "integrity": "sha512-RtgndWX8qprDn2wvx6hGJhYiokwSJc6vEwEzqUXERMB/MqQb7b8V/yIwe9IUZo91JOb61uA526LWQaFUjgbaJw==",
+      "version": "30.4.2",
+      "resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-30.4.2.tgz",
+      "integrity": "sha512-rvHH7VlY6LgbJXJTQ87GW62g1FntOtbhh0zT+v04kC+pgL6aBKyYINXxWukCpj3dcIBMw5/XUbtDS9dU9JTXeQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/environment": "30.4.0",
-        "@jest/expect": "30.4.0",
-        "@jest/test-result": "30.4.0",
-        "@jest/types": "30.4.0",
+        "@jest/environment": "30.4.1",
+        "@jest/expect": "30.4.1",
+        "@jest/test-result": "30.4.1",
+        "@jest/types": "30.4.1",
         "@types/node": "*",
         "chalk": "^4.1.2",
         "co": "^4.6.0",
         "dedent": "^1.6.0",
         "is-generator-fn": "^2.1.0",
-        "jest-each": "30.4.0",
-        "jest-matcher-utils": "30.4.0",
-        "jest-message-util": "30.4.0",
-        "jest-runtime": "30.4.0",
-        "jest-snapshot": "30.4.0",
-        "jest-util": "30.4.0",
+        "jest-each": "30.4.1",
+        "jest-matcher-utils": "30.4.1",
+        "jest-message-util": "30.4.1",
+        "jest-runtime": "30.4.2",
+        "jest-snapshot": "30.4.1",
+        "jest-util": "30.4.1",
         "p-limit": "^3.1.0",
-        "pretty-format": "30.4.0",
+        "pretty-format": "30.4.1",
         "pure-rand": "^7.0.0",
         "slash": "^3.0.0",
         "stack-utils": "^2.0.6"
@@ -2879,21 +2880,21 @@
       }
     },
     "node_modules/jest-cli": {
-      "version": "30.4.0",
-      "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-30.4.0.tgz",
-      "integrity": "sha512-N/Hd8MPTzh8EivGpgMqEzd1pTS1P9tnVKiSgztXrnGkxUr+wqpD3u+huqvxMB4KXtHuBfpVSnNJrU3y9mbOOww==",
+      "version": "30.4.2",
+      "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-30.4.2.tgz",
+      "integrity": "sha512-jfA2ocvVHMXS2QijrJ0d31ektP+d/W0T5RpcTX2Pq+3sVqHlsXVCM2+FmwpL+bdY8OfHpIg9xMxLF17Zg0U49Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/core": "30.4.0",
-        "@jest/test-result": "30.4.0",
-        "@jest/types": "30.4.0",
+        "@jest/core": "30.4.2",
+        "@jest/test-result": "30.4.1",
+        "@jest/types": "30.4.1",
         "chalk": "^4.1.2",
         "exit-x": "^0.2.2",
         "import-local": "^3.2.0",
-        "jest-config": "30.4.0",
-        "jest-util": "30.4.0",
-        "jest-validate": "30.4.0",
+        "jest-config": "30.4.2",
+        "jest-util": "30.4.1",
+        "jest-validate": "30.4.1",
         "yargs": "^17.7.2"
       },
       "bin": {
@@ -2912,33 +2913,33 @@
       }
     },
     "node_modules/jest-config": {
-      "version": "30.4.0",
-      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-30.4.0.tgz",
-      "integrity": "sha512-7JoLxH5DNk5lSpCw+AH1wTqui9crCPVezHUoro5y9Ay9Snw///woP+J2UFR5mpNFuavlOyd8endtCIHlPHSdUw==",
+      "version": "30.4.2",
+      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-30.4.2.tgz",
+      "integrity": "sha512-rNHAShJQqQwFNoL0hbf3BphSBOWnpOUAKvidLS/AjNVLPfoj5mSf4jQMfW3cYOs6hXeZC7nF7mDHaBnbxELOzg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.27.4",
         "@jest/get-type": "30.1.0",
         "@jest/pattern": "30.4.0",
-        "@jest/test-sequencer": "30.4.0",
-        "@jest/types": "30.4.0",
-        "babel-jest": "30.4.0",
+        "@jest/test-sequencer": "30.4.1",
+        "@jest/types": "30.4.1",
+        "babel-jest": "30.4.1",
         "chalk": "^4.1.2",
         "ci-info": "^4.2.0",
         "deepmerge": "^4.3.1",
         "glob": "^10.5.0",
         "graceful-fs": "^4.2.11",
-        "jest-circus": "30.4.0",
+        "jest-circus": "30.4.2",
         "jest-docblock": "30.4.0",
-        "jest-environment-node": "30.4.0",
+        "jest-environment-node": "30.4.1",
         "jest-regex-util": "30.4.0",
-        "jest-resolve": "30.4.0",
-        "jest-runner": "30.4.0",
-        "jest-util": "30.4.0",
-        "jest-validate": "30.4.0",
+        "jest-resolve": "30.4.1",
+        "jest-runner": "30.4.2",
+        "jest-util": "30.4.1",
+        "jest-validate": "30.4.1",
         "parse-json": "^5.2.0",
-        "pretty-format": "30.4.0",
+        "pretty-format": "30.4.1",
         "slash": "^3.0.0",
         "strip-json-comments": "^3.1.1"
       },
@@ -2963,16 +2964,16 @@
       }
     },
     "node_modules/jest-diff": {
-      "version": "30.4.0",
-      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-30.4.0.tgz",
-      "integrity": "sha512-8SHpYWUtt2LyH5tw5Oa+larOuy5WHDH7vklFxbxf4LJfYkepoA2eu/loHmvYDlrHrdB3JZ89197oG2A1V982yg==",
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-30.4.1.tgz",
+      "integrity": "sha512-CRpFK0RtLriVDGcPPAnR6HMVI8bSR2jnUIgralhauzYQZIb4RH9AtEInTuQr65LmmGggGcRT6HIASxwqsVsmlA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jest/diff-sequences": "30.4.0",
         "@jest/get-type": "30.1.0",
         "chalk": "^4.1.2",
-        "pretty-format": "30.4.0"
+        "pretty-format": "30.4.1"
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
@@ -2992,56 +2993,56 @@
       }
     },
     "node_modules/jest-each": {
-      "version": "30.4.0",
-      "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-30.4.0.tgz",
-      "integrity": "sha512-AusMWaBQags04/SptcZu/Ex1juOebeSozkC9Pjx+teA2zoNd0drNsZe6PseKrHWsgimatgicXJNXHr9yCvnXaw==",
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-30.4.1.tgz",
+      "integrity": "sha512-/8MJbH6fuj48TstjrMf+u/pd06Qezz5xOXvZA6442heNOWr8bdeoGZX2d9fCn028CoMgYmroH9//zky5GfyYmA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jest/get-type": "30.1.0",
-        "@jest/types": "30.4.0",
+        "@jest/types": "30.4.1",
         "chalk": "^4.1.2",
-        "jest-util": "30.4.0",
-        "pretty-format": "30.4.0"
+        "jest-util": "30.4.1",
+        "pretty-format": "30.4.1"
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "node_modules/jest-environment-node": {
-      "version": "30.4.0",
-      "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-30.4.0.tgz",
-      "integrity": "sha512-pmMYkiufguU6bqe+XP3DM24e7sCG7aYjPnCJdKiXjRh1H2SCBJgY1KC1JlIxqQjNr9dWLNpw5TLuHbXbq0CDqw==",
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-30.4.1.tgz",
+      "integrity": "sha512-4FZYVOk85hz2AyT6BbarKy9u37g6DbrDyCdFhsnDdXqyrueYQvB+0zO4f/kqLCRD0BsPRXPMNJeQwihKZV8naw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/environment": "30.4.0",
-        "@jest/fake-timers": "30.4.0",
-        "@jest/types": "30.4.0",
+        "@jest/environment": "30.4.1",
+        "@jest/fake-timers": "30.4.1",
+        "@jest/types": "30.4.1",
         "@types/node": "*",
-        "jest-mock": "30.4.0",
-        "jest-util": "30.4.0",
-        "jest-validate": "30.4.0"
+        "jest-mock": "30.4.1",
+        "jest-util": "30.4.1",
+        "jest-validate": "30.4.1"
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "node_modules/jest-haste-map": {
-      "version": "30.4.0",
-      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-30.4.0.tgz",
-      "integrity": "sha512-01+o3CS8t35Va0Ed6w/HyeK9VaejRlBnZ1hGoOlTYlruFzycn3RfIdG1Szu1DVoACTs07ALirRjECq1FqNuAFg==",
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-30.4.1.tgz",
+      "integrity": "sha512-rFrcONd8jeFsyw+Z9CrScJgglRf2+NFmNam8dKu7n+SoHqNYT47mn0DdEcVUZJpvh7Iz6/si7f7yUH7GJHVgnw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/types": "30.4.0",
+        "@jest/types": "30.4.1",
         "@types/node": "*",
         "anymatch": "^3.1.3",
         "fb-watchman": "^2.0.2",
         "graceful-fs": "^4.2.11",
         "jest-regex-util": "30.4.0",
-        "jest-util": "30.4.0",
-        "jest-worker": "30.4.0",
+        "jest-util": "30.4.1",
+        "jest-worker": "30.4.1",
         "picomatch": "^4.0.3",
         "walker": "^1.0.8"
       },
@@ -3053,50 +3054,50 @@
       }
     },
     "node_modules/jest-leak-detector": {
-      "version": "30.4.0",
-      "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-30.4.0.tgz",
-      "integrity": "sha512-n9beq0bFyt2m17RSjo6n8RsZiE1w+sOfr+p1J0aYTBXoxd/4hZeK2M7GQENKtslIsGVu2xOrNEe10CTmQfO8Mw==",
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-30.4.1.tgz",
+      "integrity": "sha512-IpmyiioeHxiWDhesHnUFmOxcTzwCwKpgACgWajtAP+nYQXiY7DakTxB6Bx9JFiRMljr0AX1PvnQdaU1KFoz6NQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jest/get-type": "30.1.0",
-        "pretty-format": "30.4.0"
+        "pretty-format": "30.4.1"
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "node_modules/jest-matcher-utils": {
-      "version": "30.4.0",
-      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-30.4.0.tgz",
-      "integrity": "sha512-m28k6fJ1hsHxYRBMbQvIfHz8FQA1e8U/I3o/Z+id0etJJL7Af6mJqMKvH11lTFX6rRKANi/8iVwdche9E+wz8w==",
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-30.4.1.tgz",
+      "integrity": "sha512-zvYfX5CaeEkFrrLS9suWe9rvJrm9J1Iv3ua8kIBv9GEPzcnsfBf0bob37la7s67fs0nlBC3EuvkOLnXQKxtx4A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jest/get-type": "30.1.0",
         "chalk": "^4.1.2",
-        "jest-diff": "30.4.0",
-        "pretty-format": "30.4.0"
+        "jest-diff": "30.4.1",
+        "pretty-format": "30.4.1"
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "node_modules/jest-message-util": {
-      "version": "30.4.0",
-      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-30.4.0.tgz",
-      "integrity": "sha512-XjJEhPYwvJezXMYuPKX52xIE7CPNNVocuUzEJcMts82HhmXii7zC3KZVjlFDXdp8khX4lwWj9Rva9bs+8oucLw==",
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-30.4.1.tgz",
+      "integrity": "sha512-kwCKIvq0MCW1HzLoGola9Te6JUdzgV0loyKJ3Qghrkz9i5/RRIHsL95BMQc2HBBhlBKC4j22K9p11TGHH8RBpQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
-        "@jest/types": "30.4.0",
+        "@jest/types": "30.4.1",
         "@types/stack-utils": "^2.0.3",
         "chalk": "^4.1.2",
         "graceful-fs": "^4.2.11",
-        "jest-util": "30.4.0",
+        "jest-util": "30.4.1",
         "picomatch": "^4.0.3",
-        "pretty-format": "30.4.0",
+        "pretty-format": "30.4.1",
         "slash": "^3.0.0",
         "stack-utils": "^2.0.6"
       },
@@ -3105,15 +3106,15 @@
       }
     },
     "node_modules/jest-mock": {
-      "version": "30.4.0",
-      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-30.4.0.tgz",
-      "integrity": "sha512-Xy8aJikWCFMLFdAvmBTWgFzik3+qnYVEqDz1n/NQQqJX14e48J31XGx+km/0INV7YPzfl6SXmjsaVidUs3zQ5Q==",
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-30.4.1.tgz",
+      "integrity": "sha512-/i8SVb8/NSB7RfNi8gfqu8gxLV23KaL5EpAttyb9iz8qWRIqXRLflycz/32wXsYkOnaUlx8NAKnJYtpsmXUmfw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/types": "30.4.0",
+        "@jest/types": "30.4.1",
         "@types/node": "*",
-        "jest-util": "30.4.0"
+        "jest-util": "30.4.1"
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
@@ -3148,18 +3149,18 @@
       }
     },
     "node_modules/jest-resolve": {
-      "version": "30.4.0",
-      "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-30.4.0.tgz",
-      "integrity": "sha512-N8Nmytv/LMGsIQXZ2kWHXC3UhzTFC696cTx3ER0jtdrIBmmNjYK6RSJPllGf6iCdj3qimKizc+nczj3kdflDOw==",
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-30.4.1.tgz",
+      "integrity": "sha512-Zry8Yq/yJcNAZ7dJ5F2heic8AheXvbFZ7XI5V+h28nrYZ7Qoyy4dItq8OodjnYD270mvX+ZudmrNV9cysqhW5Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "chalk": "^4.1.2",
         "graceful-fs": "^4.2.11",
-        "jest-haste-map": "30.4.0",
+        "jest-haste-map": "30.4.1",
         "jest-pnp-resolver": "^1.2.3",
-        "jest-util": "30.4.0",
-        "jest-validate": "30.4.0",
+        "jest-util": "30.4.1",
+        "jest-validate": "30.4.1",
         "slash": "^3.0.0",
         "unrs-resolver": "^1.7.11"
       },
@@ -3168,46 +3169,46 @@
       }
     },
     "node_modules/jest-resolve-dependencies": {
-      "version": "30.4.0",
-      "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-30.4.0.tgz",
-      "integrity": "sha512-2iooc09EwOjWpyIe03NQ4V7kgKZgs6TtO3vSydMUjTXjQhmj/0wWX/n4qbWw/K3LEMUkBhEuk3QHVWEC7k79nw==",
+      "version": "30.4.2",
+      "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-30.4.2.tgz",
+      "integrity": "sha512-gDiVh1I+GxYzz9oXlyw+1wv6VOYX1WYxMOfjsA3iGKePV2oxmbHhwxfkALxNxYy1ciw6APWwkW2zZONwP97aEQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "jest-regex-util": "30.4.0",
-        "jest-snapshot": "30.4.0"
+        "jest-snapshot": "30.4.1"
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "node_modules/jest-runner": {
-      "version": "30.4.0",
-      "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-30.4.0.tgz",
-      "integrity": "sha512-9LKu3gQKGvOIbzVh/xkoEYW2+/xDRjZ5/TU2Kqb1aC9TNYd3egENB0+0MXoTfaLNH1TlrIISTl6lABNHOuo3Iw==",
+      "version": "30.4.2",
+      "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-30.4.2.tgz",
+      "integrity": "sha512-2dw0PslVYXxffXGpLo+Ejad+KcI1Qkjn7f4X4619gf21oCUmL+SPfjqIa/losUem3yEOvfNZe/F1HWUcNpODcg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/console": "30.4.0",
-        "@jest/environment": "30.4.0",
-        "@jest/test-result": "30.4.0",
-        "@jest/transform": "30.4.0",
-        "@jest/types": "30.4.0",
+        "@jest/console": "30.4.1",
+        "@jest/environment": "30.4.1",
+        "@jest/test-result": "30.4.1",
+        "@jest/transform": "30.4.1",
+        "@jest/types": "30.4.1",
         "@types/node": "*",
         "chalk": "^4.1.2",
         "emittery": "^0.13.1",
         "exit-x": "^0.2.2",
         "graceful-fs": "^4.2.11",
         "jest-docblock": "30.4.0",
-        "jest-environment-node": "30.4.0",
-        "jest-haste-map": "30.4.0",
-        "jest-leak-detector": "30.4.0",
-        "jest-message-util": "30.4.0",
-        "jest-resolve": "30.4.0",
-        "jest-runtime": "30.4.0",
-        "jest-util": "30.4.0",
-        "jest-watcher": "30.4.0",
-        "jest-worker": "30.4.0",
+        "jest-environment-node": "30.4.1",
+        "jest-haste-map": "30.4.1",
+        "jest-leak-detector": "30.4.1",
+        "jest-message-util": "30.4.1",
+        "jest-resolve": "30.4.1",
+        "jest-runtime": "30.4.2",
+        "jest-util": "30.4.1",
+        "jest-watcher": "30.4.1",
+        "jest-worker": "30.4.1",
         "p-limit": "^3.1.0",
         "source-map-support": "0.5.13"
       },
@@ -3216,32 +3217,32 @@
       }
     },
     "node_modules/jest-runtime": {
-      "version": "30.4.0",
-      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-30.4.0.tgz",
-      "integrity": "sha512-xPjd7AStvPrnP/lZr+Urp7GPS9MFQDrWBtjXZYMuYZnQeFvkw5xM0jpjpGUxhsYYf4q3JY80SPlld7U2Sy9hyA==",
+      "version": "30.4.2",
+      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-30.4.2.tgz",
+      "integrity": "sha512-3/5e8iPz2k/VLqlr8DgTftYyLUv8Su3FkCAO2/Od81UsUTpSxOrS6O5x5KkoQwyUjmpYyDJKeyAvg2T2nvpNkQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/environment": "30.4.0",
-        "@jest/fake-timers": "30.4.0",
-        "@jest/globals": "30.4.0",
+        "@jest/environment": "30.4.1",
+        "@jest/fake-timers": "30.4.1",
+        "@jest/globals": "30.4.1",
         "@jest/source-map": "30.0.1",
-        "@jest/test-result": "30.4.0",
-        "@jest/transform": "30.4.0",
-        "@jest/types": "30.4.0",
+        "@jest/test-result": "30.4.1",
+        "@jest/transform": "30.4.1",
+        "@jest/types": "30.4.1",
         "@types/node": "*",
         "chalk": "^4.1.2",
         "cjs-module-lexer": "^2.1.0",
         "collect-v8-coverage": "^1.0.2",
         "glob": "^10.5.0",
         "graceful-fs": "^4.2.11",
-        "jest-haste-map": "30.4.0",
-        "jest-message-util": "30.4.0",
-        "jest-mock": "30.4.0",
+        "jest-haste-map": "30.4.1",
+        "jest-message-util": "30.4.1",
+        "jest-mock": "30.4.1",
         "jest-regex-util": "30.4.0",
-        "jest-resolve": "30.4.0",
-        "jest-snapshot": "30.4.0",
-        "jest-util": "30.4.0",
+        "jest-resolve": "30.4.1",
+        "jest-snapshot": "30.4.1",
+        "jest-util": "30.4.1",
         "slash": "^3.0.0",
         "strip-bom": "^4.0.0"
       },
@@ -3250,9 +3251,9 @@
       }
     },
     "node_modules/jest-snapshot": {
-      "version": "30.4.0",
-      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-30.4.0.tgz",
-      "integrity": "sha512-2OdJoU/ogYJOAnbTG6FCelziKiyDZA1FocmO1xnKLfOb4J2gpHXsJC5nAP7wfG/VgwJxtM06ZUYz7rJmAhOsLw==",
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-30.4.1.tgz",
+      "integrity": "sha512-tEOkkfOMppUyeiHwjZswOQ3lcnoTnws/q5FnGIaeIh/jmoU0ZlgMYRR8sTlTj+nNGCoJ0RDq6SfxGxCsyMTPmw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3261,20 +3262,20 @@
         "@babel/plugin-syntax-jsx": "^7.27.1",
         "@babel/plugin-syntax-typescript": "^7.27.1",
         "@babel/types": "^7.27.3",
-        "@jest/expect-utils": "30.4.0",
+        "@jest/expect-utils": "30.4.1",
         "@jest/get-type": "30.1.0",
-        "@jest/snapshot-utils": "30.4.0",
-        "@jest/transform": "30.4.0",
-        "@jest/types": "30.4.0",
+        "@jest/snapshot-utils": "30.4.1",
+        "@jest/transform": "30.4.1",
+        "@jest/types": "30.4.1",
         "babel-preset-current-node-syntax": "^1.2.0",
         "chalk": "^4.1.2",
-        "expect": "30.4.0",
+        "expect": "30.4.1",
         "graceful-fs": "^4.2.11",
-        "jest-diff": "30.4.0",
-        "jest-matcher-utils": "30.4.0",
-        "jest-message-util": "30.4.0",
-        "jest-util": "30.4.0",
-        "pretty-format": "30.4.0",
+        "jest-diff": "30.4.1",
+        "jest-matcher-utils": "30.4.1",
+        "jest-message-util": "30.4.1",
+        "jest-util": "30.4.1",
+        "pretty-format": "30.4.1",
         "semver": "^7.7.2",
         "synckit": "^0.11.8"
       },
@@ -3283,9 +3284,9 @@
       }
     },
     "node_modules/jest-snapshot/node_modules/semver": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
+      "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -3296,13 +3297,13 @@
       }
     },
     "node_modules/jest-util": {
-      "version": "30.4.0",
-      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.4.0.tgz",
-      "integrity": "sha512-nae+Oh7CEdSTC5+uL4HCVDCLusj5IcypnVXWBSRjCUDkh7dX/FwreTsgvLROwHnEWW5dcdvLkW9RvmmMzKw+aw==",
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.4.1.tgz",
+      "integrity": "sha512-vjQb1sACEiv13DKJMDToJpzVW0joCsIQrmbg0fi7CyOOt+g9jTuQl2A216pWRBYhOVt53XbL/2LbMKg1BECWOw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/types": "30.4.0",
+        "@jest/types": "30.4.1",
         "@types/node": "*",
         "chalk": "^4.1.2",
         "ci-info": "^4.2.0",
@@ -3314,18 +3315,18 @@
       }
     },
     "node_modules/jest-validate": {
-      "version": "30.4.0",
-      "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-30.4.0.tgz",
-      "integrity": "sha512-tIzxS3lajj3BAELRD1bde4GdsZFU9gwUYlyGoKq23XNR7oaeYQRt7KKA38VxGNoLJpkJ5jQBs9Q0fhefXnol0g==",
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-30.4.1.tgz",
+      "integrity": "sha512-PDWi4SOwLnwqNDfHZjOcsEFyZ4fc/2W2gVL3DEoyqnB6jCQMLRtfBong8s6omIw3lI0HWOus12xfnFmQtjW3fw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jest/get-type": "30.1.0",
-        "@jest/types": "30.4.0",
+        "@jest/types": "30.4.1",
         "camelcase": "^6.3.0",
         "chalk": "^4.1.2",
         "leven": "^3.1.0",
-        "pretty-format": "30.4.0"
+        "pretty-format": "30.4.1"
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
@@ -3345,19 +3346,19 @@
       }
     },
     "node_modules/jest-watcher": {
-      "version": "30.4.0",
-      "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-30.4.0.tgz",
-      "integrity": "sha512-VPLgD4ZydEWWY8B/edBUwLsTANwaLM8R1NA1M0szFKkgjWmP6F6w7T+c6rtUYuE5r/5SsFLGwGkvmrlS4JHiwQ==",
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-30.4.1.tgz",
+      "integrity": "sha512-/l9UonmvCwjHH7d2h3iAwIloLc1H0S8mJZ/LNK3i86hqwPAz8otUJjP9MfYtz9Tt77Su5FD2xGjZn8d31IZHlw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/test-result": "30.4.0",
-        "@jest/types": "30.4.0",
+        "@jest/test-result": "30.4.1",
+        "@jest/types": "30.4.1",
         "@types/node": "*",
         "ansi-escapes": "^4.3.2",
         "chalk": "^4.1.2",
         "emittery": "^0.13.1",
-        "jest-util": "30.4.0",
+        "jest-util": "30.4.1",
         "string-length": "^4.0.2"
       },
       "engines": {
@@ -3365,15 +3366,15 @@
       }
     },
     "node_modules/jest-worker": {
-      "version": "30.4.0",
-      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-30.4.0.tgz",
-      "integrity": "sha512-0ZghqNv1P/M0nBysxrkGpLnorjM1ulhZ76QijLcwyBm+kIj/DPKyHcpHDVh0LD05JDZzVxi8z9RStF22B4gikQ==",
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-30.4.1.tgz",
+      "integrity": "sha512-SHynN/q/QD++iNyvMdy+WMmbCGk8jIsNcRxycXbWubSOhvo6T+j2afcfUSl+3hYsiBebOTo0cT7c2H7CXugu1g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*",
         "@ungap/structured-clone": "^1.3.0",
-        "jest-util": "30.4.0",
+        "jest-util": "30.4.1",
         "merge-stream": "^2.0.0",
         "supports-color": "^8.1.1"
       },
@@ -3508,9 +3509,9 @@
       }
     },
     "node_modules/make-dir/node_modules/semver": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
+      "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -3875,13 +3876,13 @@
       }
     },
     "node_modules/pretty-format": {
-      "version": "30.4.0",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.4.0.tgz",
-      "integrity": "sha512-PzJLEF72RqCj01UTBWqBi2ar3U2iJ0oG0+HzcdHPW+rzfpzDCuiVeiy6lns8L3Nbpp4Ajw+nBsW2KuKPPyPlCw==",
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.4.1.tgz",
+      "integrity": "sha512-K6KiKMHTL4jjX4u3Kir2EW07nRfcqVTXIImx50wbjHQTcZPgg+gjVeNTIT3l3L1Rd4UefxfogquC9J37SoFyyw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/schemas": "30.4.0",
+        "@jest/schemas": "30.4.1",
         "ansi-styles": "^5.2.0",
         "react-is-18": "npm:react-is@^18.3.1",
         "react-is-19": "npm:react-is@^19.2.5"


### PR DESCRIPTION
## Summary

Migrates code ownership from the `@ydesgagn` user to the `@Cloud-Officer/maintainers` team, switches the auto-merge workflow approval step to use a bot personal access token instead of the default `GITHUB_TOKEN`, and refreshes the slack action's transitive dependency lockfile.

**Key changes:**

- Replace `@ydesgagn` with `@Cloud-Officer/maintainers` across `.github/CODEOWNERS` for both the catch-all owner and per-pattern owners
- Use `secrets.GH_BOT_PAT` instead of `secrets.GITHUB_TOKEN` for the approval step in `.github/workflows/auto-merge.yml` so the approval is attributed to the bot account and can satisfy required-review rules
- Refresh `slack/package-lock.json` with updated transitive dependencies

## Types of changes

- [ ] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [x] Build or security update (updates dependencies, libraries, or security patches)
- [ ] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

- [ ] Unit tests added to validate my fix/feature
- [ ] I have manually tested my change
- [ ] I did not add automation test. Why ?:
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] `readme.md` includes sections on introduction, installation, usage, and contributing
- [ ] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified