### PR TITLE
Capitalize Maintainers team in CODEOWNERS and ignore code-review.md

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,12 +4,12 @@
 
 # build/deploy related files
 
-.eslintrc.json           @Cloud-Officer/maintainers
-.github/                 @Cloud-Officer/maintainers
-.gitignore               @Cloud-Officer/maintainers
-.markdownlint-cli2.yaml  @Cloud-Officer/maintainers
-.ruby-version            @Cloud-Officer/maintainers
-.shellcheckrc            @Cloud-Officer/maintainers
-.yamllint.yml            @Cloud-Officer/maintainers
-codedeploy/              @Cloud-Officer/maintainers
-*.sh                     @Cloud-Officer/maintainers
+.eslintrc.json           @Cloud-Officer/Maintainers
+.github/                 @Cloud-Officer/Maintainers
+.gitignore               @Cloud-Officer/Maintainers
+.markdownlint-cli2.yaml  @Cloud-Officer/Maintainers
+.ruby-version            @Cloud-Officer/Maintainers
+.shellcheckrc            @Cloud-Officer/Maintainers
+.yamllint.yml            @Cloud-Officer/Maintainers
+codedeploy/              @Cloud-Officer/Maintainers
+*.sh                     @Cloud-Officer/Maintainers

--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -13,6 +13,7 @@ globs:
   - "!**/dist/**"
   - "!**/build/**"
   - "!**/target/**"
+  - "!docs/code-review.md"
 config:
   default: true
   first-line-heading: false


### PR DESCRIPTION
## Summary

Aligns the CODEOWNERS team reference with the canonical GitHub team name casing and excludes the generated code review document from markdown linting.

**Key changes:**

- Rename `@Cloud-Officer/maintainers` to `@Cloud-Officer/Maintainers` across all entries in `.github/CODEOWNERS` to match the actual team slug casing
- Add `!docs/code-review.md` to the markdownlint-cli2 ignore globs so the generated code review document is not linted

## Types of changes

- [ ] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [ ] Build or security update (updates dependencies, libraries, or security patches)
- [x] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

- [ ] Unit tests added to validate my fix/feature
- [x] I have manually tested my change
- [x] I did not add automation test. Why ?: Configuration-only change (team name casing and lint ignore glob).
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] `readme.md` includes sections on introduction, installation, usage, and contributing
- [ ] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified