### PR TITLE
Deduplicate the linter-enabled gate across all 19 linter actions (QUAL-001)

### DIFF
--- a/linters/_lib/check_enabled.sh
+++ b/linters/_lib/check_enabled.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+# Shared "is this linter enabled" gate for every linters/*/action.yml.
+#
+# Usage (from a composite action step):
+#   run: bash "${GITHUB_ACTION_PATH}/../_lib/check_enabled.sh" LINTER_NAME
+#
+# Reads the space-separated LINTERS list from the environment and writes
+# continue=true|false to GITHUB_OUTPUT so subsequent steps can gate on
+# steps.check.outputs.continue. Centralised here so a change to the gating
+# logic is one edit instead of 19.
+
+set -euo pipefail
+
+linter_name="${1:?usage: check_enabled.sh LINTER_NAME}"
+
+if echo "${LINTERS:-}" | grep -- "${linter_name}" &> /dev/null; then
+  echo "continue=true" >> "${GITHUB_OUTPUT}"
+else
+  echo "continue=false" >> "${GITHUB_OUTPUT}"
+fi

--- a/linters/actionlint/action.yml
+++ b/linters/actionlint/action.yml
@@ -22,7 +22,7 @@ runs:
       env:
         GITHUB_TOKEN: ${{ inputs.github-token }}
         LINTERS: ${{ inputs.linters }}
-      run: if echo "${LINTERS}" | grep ACTIONLINT &> /dev/null; then echo "continue=true" >> "${GITHUB_OUTPUT}"; else echo "continue=false" >> "${GITHUB_OUTPUT}"; fi
+      run: bash "${GITHUB_ACTION_PATH}/../_lib/check_enabled.sh" ACTIONLINT
 
     # https://github.com/marketplace/actions/checkout
     - name: Checkout

--- a/linters/bandit/action.yml
+++ b/linters/bandit/action.yml
@@ -22,7 +22,7 @@ runs:
       env:
         GITHUB_TOKEN: ${{ inputs.github-token }}
         LINTERS: ${{ inputs.linters }}
-      run: if echo "${LINTERS}" | grep BANDIT &> /dev/null; then echo "continue=true" >> "${GITHUB_OUTPUT}"; else echo "continue=false" >> "${GITHUB_OUTPUT}"; fi
+      run: bash "${GITHUB_ACTION_PATH}/../_lib/check_enabled.sh" BANDIT
 
     # https://github.com/marketplace/actions/checkout
     - name: Checkout

--- a/linters/cfnlint/action.yml
+++ b/linters/cfnlint/action.yml
@@ -23,7 +23,7 @@ runs:
       env:
         GITHUB_TOKEN: ${{ inputs.github-token }}
         LINTERS: ${{ inputs.linters }}
-      run: if echo "${LINTERS}" | grep CFNLINT &> /dev/null; then echo "continue=true" >> "${GITHUB_OUTPUT}"; else echo "continue=false" >> "${GITHUB_OUTPUT}"; fi
+      run: bash "${GITHUB_ACTION_PATH}/../_lib/check_enabled.sh" CFNLINT
 
     # https://github.com/marketplace/actions/checkout
     - name: Checkout

--- a/linters/eslint/action.yml
+++ b/linters/eslint/action.yml
@@ -22,7 +22,7 @@ runs:
       env:
         GITHUB_TOKEN: ${{ inputs.github-token }}
         LINTERS: ${{ inputs.linters }}
-      run: if echo "${LINTERS}" | grep ESLINT &> /dev/null; then echo "continue=true" >> "${GITHUB_OUTPUT}"; else echo "continue=false" >> "${GITHUB_OUTPUT}"; fi
+      run: bash "${GITHUB_ACTION_PATH}/../_lib/check_enabled.sh" ESLINT
 
     # https://github.com/marketplace/actions/checkout
     - name: Checkout

--- a/linters/flake8/action.yml
+++ b/linters/flake8/action.yml
@@ -23,7 +23,7 @@ runs:
       env:
         GITHUB_TOKEN: ${{ inputs.github-token }}
         LINTERS: ${{ inputs.linters }}
-      run: if echo "${LINTERS}" | grep FLAKE8 &> /dev/null; then echo "continue=true" >> "${GITHUB_OUTPUT}"; else echo "continue=false" >> "${GITHUB_OUTPUT}"; fi
+      run: bash "${GITHUB_ACTION_PATH}/../_lib/check_enabled.sh" FLAKE8
 
     # https://github.com/marketplace/actions/checkout
     - name: Checkout

--- a/linters/golangci/action.yml
+++ b/linters/golangci/action.yml
@@ -23,7 +23,7 @@ runs:
       env:
         GITHUB_TOKEN: ${{ inputs.github-token }}
         LINTERS: ${{ inputs.linters }}
-      run: if echo "${LINTERS}" | grep GOLANGCI &> /dev/null; then echo "continue=true" >> "${GITHUB_OUTPUT}"; else echo "continue=false" >> "${GITHUB_OUTPUT}"; fi
+      run: bash "${GITHUB_ACTION_PATH}/../_lib/check_enabled.sh" GOLANGCI
 
     # https://github.com/marketplace/actions/checkout
     - name: Checkout

--- a/linters/hadolint/action.yml
+++ b/linters/hadolint/action.yml
@@ -23,7 +23,7 @@ runs:
       env:
         GITHUB_TOKEN: ${{ inputs.github-token }}
         LINTERS: ${{ inputs.linters }}
-      run: if echo "${LINTERS}" | grep HADOLINT &> /dev/null; then echo "continue=true" >> "${GITHUB_OUTPUT}"; else echo "continue=false" >> "${GITHUB_OUTPUT}"; fi
+      run: bash "${GITHUB_ACTION_PATH}/../_lib/check_enabled.sh" HADOLINT
 
     # https://github.com/marketplace/actions/checkout
     - name: Checkout

--- a/linters/ktlint/action.yml
+++ b/linters/ktlint/action.yml
@@ -23,7 +23,7 @@ runs:
       env:
         GITHUB_TOKEN: ${{ inputs.github-token }}
         LINTERS: ${{ inputs.linters }}
-      run: if echo "${LINTERS}" | grep KTLINT &> /dev/null; then echo "continue=true" >> "${GITHUB_OUTPUT}"; else echo "continue=false" >> "${GITHUB_OUTPUT}"; fi
+      run: bash "${GITHUB_ACTION_PATH}/../_lib/check_enabled.sh" KTLINT
 
     # https://github.com/marketplace/actions/checkout
     - name: Checkout

--- a/linters/markdownlint/action.yml
+++ b/linters/markdownlint/action.yml
@@ -23,7 +23,7 @@ runs:
       env:
         GITHUB_TOKEN: ${{ inputs.github-token }}
         LINTERS: ${{ inputs.linters }}
-      run: if echo "${LINTERS}" | grep MARKDOWNLINT &> /dev/null; then echo "continue=true" >> "${GITHUB_OUTPUT}"; else echo "continue=false" >> "${GITHUB_OUTPUT}"; fi
+      run: bash "${GITHUB_ACTION_PATH}/../_lib/check_enabled.sh" MARKDOWNLINT
 
     # https://github.com/marketplace/actions/checkout
     - name: Checkout

--- a/linters/phpcs/action.yml
+++ b/linters/phpcs/action.yml
@@ -43,7 +43,7 @@ runs:
       env:
         GITHUB_TOKEN: ${{ inputs.github-token }}
         LINTERS: ${{ inputs.linters }}
-      run: if echo "${LINTERS}" | grep PHPCS &> /dev/null; then echo "continue=true" >> "${GITHUB_OUTPUT}"; else echo "continue=false" >> "${GITHUB_OUTPUT}"; fi
+      run: bash "${GITHUB_ACTION_PATH}/../_lib/check_enabled.sh" PHPCS
 
     # https://github.com/marketplace/actions/checkout
     - name: Checkout

--- a/linters/phpstan/action.yml
+++ b/linters/phpstan/action.yml
@@ -43,7 +43,7 @@ runs:
       env:
         GITHUB_TOKEN: ${{ inputs.github-token }}
         LINTERS: ${{ inputs.linters }}
-      run: if echo "${LINTERS}" | grep PHPSTAN &> /dev/null; then echo "continue=true" >> "${GITHUB_OUTPUT}"; else echo "continue=false" >> "${GITHUB_OUTPUT}"; fi
+      run: bash "${GITHUB_ACTION_PATH}/../_lib/check_enabled.sh" PHPSTAN
 
     # https://github.com/marketplace/actions/checkout
     - name: Checkout

--- a/linters/pmd/action.yml
+++ b/linters/pmd/action.yml
@@ -23,7 +23,7 @@ runs:
       env:
         GITHUB_TOKEN: ${{ inputs.github-token }}
         LINTERS: ${{ inputs.linters }}
-      run: if echo "${LINTERS}" | grep PMD &> /dev/null; then echo "continue=true" >> "${GITHUB_OUTPUT}"; else echo "continue=false" >> "${GITHUB_OUTPUT}"; fi
+      run: bash "${GITHUB_ACTION_PATH}/../_lib/check_enabled.sh" PMD
 
     # https://github.com/marketplace/actions/checkout
     - name: Checkout

--- a/linters/protolint/action.yml
+++ b/linters/protolint/action.yml
@@ -23,7 +23,7 @@ runs:
       env:
         GITHUB_TOKEN: ${{ inputs.github-token }}
         LINTERS: ${{ inputs.linters }}
-      run: if echo "${LINTERS}" | grep PROTOLINT &> /dev/null; then echo "continue=true" >> "${GITHUB_OUTPUT}"; else echo "continue=false" >> "${GITHUB_OUTPUT}"; fi
+      run: bash "${GITHUB_ACTION_PATH}/../_lib/check_enabled.sh" PROTOLINT
 
     # https://github.com/marketplace/actions/checkout
     - name: Checkout

--- a/linters/rubocop/action.yml
+++ b/linters/rubocop/action.yml
@@ -27,7 +27,7 @@ runs:
       env:
         GITHUB_TOKEN: ${{ inputs.github-token }}
         LINTERS: ${{ inputs.linters }}
-      run: if echo "${LINTERS}" | grep RUBOCOP &> /dev/null; then echo "continue=true" >> "${GITHUB_OUTPUT}"; else echo "continue=false" >> "${GITHUB_OUTPUT}"; fi
+      run: bash "${GITHUB_ACTION_PATH}/../_lib/check_enabled.sh" RUBOCOP
 
     # https://github.com/marketplace/actions/checkout
     - name: Checkout

--- a/linters/semgrep/action.yml
+++ b/linters/semgrep/action.yml
@@ -22,7 +22,7 @@ runs:
       env:
         GITHUB_TOKEN: ${{ inputs.github-token }}
         LINTERS: ${{ inputs.linters }}
-      run: if echo "${LINTERS}" | grep SEMGREP &> /dev/null; then echo "continue=true" >> "${GITHUB_OUTPUT}"; else echo "continue=false" >> "${GITHUB_OUTPUT}"; fi
+      run: bash "${GITHUB_ACTION_PATH}/../_lib/check_enabled.sh" SEMGREP
 
     # https://github.com/marketplace/actions/checkout
     - name: Checkout

--- a/linters/shellcheck/action.yml
+++ b/linters/shellcheck/action.yml
@@ -23,7 +23,7 @@ runs:
       env:
         GITHUB_TOKEN: ${{ inputs.github-token }}
         LINTERS: ${{ inputs.linters }}
-      run: if echo "${LINTERS}" | grep SHELLCHECK &> /dev/null; then echo "continue=true" >> "${GITHUB_OUTPUT}"; else echo "continue=false" >> "${GITHUB_OUTPUT}"; fi
+      run: bash "${GITHUB_ACTION_PATH}/../_lib/check_enabled.sh" SHELLCHECK
 
     # https://github.com/marketplace/actions/checkout
     - name: Checkout

--- a/linters/swiftlint/action.yml
+++ b/linters/swiftlint/action.yml
@@ -23,7 +23,7 @@ runs:
       env:
         GITHUB_TOKEN: ${{ inputs.github-token }}
         LINTERS: ${{ inputs.linters }}
-      run: if echo "${LINTERS}" | grep SWIFTLINT &> /dev/null; then echo "continue=true" >> "${GITHUB_OUTPUT}"; else echo "continue=false" >> "${GITHUB_OUTPUT}"; fi
+      run: bash "${GITHUB_ACTION_PATH}/../_lib/check_enabled.sh" SWIFTLINT
 
     # https://github.com/marketplace/actions/checkout
     - name: Checkout

--- a/linters/trivy/action.yml
+++ b/linters/trivy/action.yml
@@ -23,7 +23,7 @@ runs:
       env:
         GITHUB_TOKEN: ${{ inputs.github-token }}
         LINTERS: ${{ inputs.linters }}
-      run: if echo "${LINTERS}" | grep TRIVY &> /dev/null; then echo "continue=true" >> "${GITHUB_OUTPUT}"; else echo "continue=false" >> "${GITHUB_OUTPUT}"; fi
+      run: bash "${GITHUB_ACTION_PATH}/../_lib/check_enabled.sh" TRIVY
 
     # https://github.com/marketplace/actions/checkout
     - name: Checkout

--- a/linters/yamllint/action.yml
+++ b/linters/yamllint/action.yml
@@ -23,7 +23,7 @@ runs:
       env:
         GITHUB_TOKEN: ${{ inputs.github-token }}
         LINTERS: ${{ inputs.linters }}
-      run: if echo "${LINTERS}" | grep YAMLLINT &> /dev/null; then echo "continue=true" >> "${GITHUB_OUTPUT}"; else echo "continue=false" >> "${GITHUB_OUTPUT}"; fi
+      run: bash "${GITHUB_ACTION_PATH}/../_lib/check_enabled.sh" YAMLLINT
 
     # https://github.com/marketplace/actions/checkout
     - name: Checkout


### PR DESCRIPTION
## Summary

Every `linters/*/action.yml` repeated the same "is this linter enabled" gate — an identical `if echo "${LINTERS}" | grep <NAME> ...` line that only differed by the linter token. Any change to the gating logic meant editing 19 files. This centralises it into one shared script.

**Key changes:**

- Add `linters/_lib/check_enabled.sh` — reads `LINTERS` from the env and writes `continue=true|false` to `GITHUB_OUTPUT`; `set -euo pipefail`, defensive arg/var handling.
- Replace the inline gate in all 19 linter actions with `bash "${GITHUB_ACTION_PATH}/../_lib/check_enabled.sh" <NAME>`. `GITHUB_ACTION_PATH` resolves to the checked-out action directory, so the shared script is referenced from a sibling path with no fragile cross-action `@ref` and no dependency on the consumer repo being checked out (a local `./` action would not resolve in consumer repos).

Behaviour is unchanged — verified the shared gate produces `continue=true` when the linter is listed, `continue=false` when it is absent or `LINTERS` is empty, and exits 0 in all cases (matching the previous inline logic).

Not included: **QUAL-002** (the 5 duplicated reviewdog `with:` inputs across 9 linters) is intentionally left out. Those 9 calls use 7 *different* `reviewdog/action-*` actions; GitHub composite YAML cannot parameterise `uses:`, has no YAML anchors, and a shared wrapper composite would hit the same local-ref limitation. Reducing it safely needs the workflow generator to emit those blocks (or accepting the 5-line constant duplication) — out of scope for this self-contained refactor and best tracked separately.

## Types of changes

- [ ] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [x] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [ ] Build or security update (updates dependencies, libraries, or security patches)
- [ ] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

- [ ] Unit tests added to validate my fix/feature
- [x] I have manually tested my change
- [x] I did not add automation test. Why ?: composite-action test harness does not exist yet (tracked as TEST-002); the shared gate was verified by simulating enabled/disabled/empty LINTERS against the script, plus shellcheck and yamllint
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] \`readme.md\` includes sections on introduction, installation, usage, and contributing
- [ ] \`docs/architecture.md\` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified