### PR TITLE
Add regenerated github-build output (Python Bandit/Flake8 linters)

### DIFF
--- a/.bandit
+++ b/.bandit
@@ -1,0 +1,4 @@
+[bandit]
+targets: .
+recursive: yes
+exclude: node_modules,vendor,.build,Pods,Carthage,DerivedData,venv,.venv,dist,build,target

--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,3 @@
+[flake8]
+ignore = E501,W503,D200,D202,D204,D205,D210,D400,D401,D403,E402
+extend-exclude = node_modules,vendor,Libraries,Pods,.build,Carthage,DerivedData,venv,.venv,dist,build,target

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,6 +63,20 @@ jobs:
         linters: "${{needs.variables.outputs.LINTERS}}"
         ssh-key: "${{secrets.SSH_KEY}}"
         github-token: "${{secrets.GH_PAT}}"
+  bandit:
+    name: Python Bandit Linter
+    runs-on: ubuntu-latest
+    needs:
+    - variables
+    if: "${{needs.variables.outputs.SKIP_LINTERS != '1'}}"
+    timeout-minutes: 30
+    steps:
+    - name: Bandit
+      uses: cloud-officer/ci-actions/linters/bandit@v2
+      with:
+        linters: "${{needs.variables.outputs.LINTERS}}"
+        ssh-key: "${{secrets.SSH_KEY}}"
+        github-token: "${{secrets.GH_PAT}}"
   eslint:
     name: JavaScript ES Linter
     runs-on: ubuntu-latest
@@ -74,6 +88,20 @@ jobs:
     - name: ESLint
       id: eslint
       uses: cloud-officer/ci-actions/linters/eslint@v2
+      with:
+        linters: "${{needs.variables.outputs.LINTERS}}"
+        ssh-key: "${{secrets.SSH_KEY}}"
+        github-token: "${{secrets.GH_PAT}}"
+  flake8:
+    name: Python Flake8 Linter
+    runs-on: ubuntu-latest
+    needs:
+    - variables
+    if: "${{needs.variables.outputs.SKIP_LINTERS != '1' && github.event_name == 'pull_request'}}"
+    timeout-minutes: 30
+    steps:
+    - name: Flake8
+      uses: cloud-officer/ci-actions/linters/flake8@v2
       with:
         linters: "${{needs.variables.outputs.LINTERS}}"
         ssh-key: "${{secrets.SSH_KEY}}"

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-# Edit at https://www.toptal.com/developers/gitignore?templates=eclipse,emacs,jetbrains,linux,macos,netbeans,nova,ruby,sublimetext,vim,visualstudiocode,webstorm,windows
+# Edit at https://www.toptal.com/developers/gitignore?templates=eclipse,emacs,jetbrains,linux,macos,netbeans,nova,pycharm,python,ruby,sublimetext,vim,visualstudiocode,webstorm,windows
 
 ### Eclipse ###
 .metadata
@@ -286,6 +286,250 @@ nbdist/
 ### nova ###
 .nova/*
 
+### PyCharm ###
+# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio, WebStorm and Rider
+# Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
+
+# User-specific stuff
+
+# AWS User-specific
+
+# Generated files
+
+# Sensitive or high-churn files
+
+# Gradle
+
+# Gradle and Maven with auto-import
+# When using Gradle or Maven with auto-import, you should exclude module files,
+# since they will be recreated, and may cause churn.  Uncomment if using
+auto-import.
+.idea/artifacts
+.idea/compiler.xml
+.idea/jarRepositories.xml
+.idea/modules.xml
+.idea/*.iml
+.idea/modules
+*.iml
+*.ipr
+
+# CMake
+
+# Mongo Explorer plugin
+
+# File-based project format
+
+# IntelliJ
+
+# mpeltonen/sbt-idea plugin
+
+# JIRA plugin
+
+# Cursive Clojure plugin
+
+# SonarLint plugin
+
+# Crashlytics plugin (for Android Studio and IntelliJ)
+
+# Editor-based Rest Client
+
+# Android studio 3.1+ serialized cache file
+
+### PyCharm Patch ###
+# Comment Reason: https://github.com/joeblau/gitignore.io/issues/186#issuecomment-215987721
+*.iml
+modules.xml
+.idea/misc.xml
+*.ipr
+
+# Sonarlint plugin
+# https://plugins.jetbrains.com/plugin/7973-sonarlint
+
+# SonarQube Plugin
+# https://plugins.jetbrains.com/plugin/7238-sonarqube-community-plugin
+
+# Markdown Navigator plugin
+# https://plugins.jetbrains.com/plugin/7896-markdown-navigator-enhanced
+
+# Cache file creation bug
+# See https://youtrack.jetbrains.com/issue/JBR-2257
+
+# CodeStream plugin
+# https://plugins.jetbrains.com/plugin/12206-codestream
+
+# Azure Toolkit for IntelliJ plugin
+# https://plugins.jetbrains.com/plugin/8053-azure-toolkit-for-intellij
+
+### Python ###
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+develop-eggs/
+downloads/
+eggs/
+.eggs/
+# lib/
+lib64/
+parts/
+sdist/
+# var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# poetry
+#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
+#poetry.lock
+
+# pdm
+#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
+#pdm.lock
+#   pdm stores project-wide configurations in .pdm.toml, but it is recommended to not include it
+#   in version control.
+#   https://pdm.fming.dev/#use-with-ide
+.pdm.toml
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# PyCharm
+#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
+#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#  and can be added to the global gitignore or merged into this file.  For a more nuclear
+#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
+#.idea/
+
+### Python Patch ###
+# Poetry local configuration file - https://python-poetry.org/docs/configuration/#local-configuration
+poetry.toml
+
+# ruff
+.ruff_cache/
+
+# LSP config files
+pyrightconfig.json
+
 ### Ruby ###
 *.gem
 *.rbc
@@ -514,7 +758,7 @@ $RECYCLE.BIN/
 # Windows shortcuts
 *.lnk
 
-# End of https://www.toptal.com/developers/gitignore/api/eclipse,emacs,jetbrains,linux,macos,netbeans,nova,ruby,sublimetext,vim,visualstudiocode,webstorm,windows
+# End of https://www.toptal.com/developers/gitignore/api/eclipse,emacs,jetbrains,linux,macos,netbeans,nova,pycharm,python,ruby,sublimetext,vim,visualstudiocode,webstorm,windows
 
 # BEGIN AI Assistants
 


### PR DESCRIPTION
## Summary

Activating the smoke-test required checks meant running github-build (local checkout, with the merged #386–#388) against ci-actions with `--sync_required_status_checks`. That run set branch protection on `master` to require the smoke jobs (`Action contracts (all 28)`, `Linter actions (disabled path)`, `Variables action`) — already done and verified live. The same run also detected Python (the `tests/action_contracts.py` added in TEST-002), so github-build now wants the Python Bandit and Flake8 linters and regenerated the corresponding files. This PR commits that regenerated output so `master` matches the branch protection the run already applied.

**Key changes:**

- `.github/workflows/build.yml` — adds the generated `Python Bandit Linter` and `Python Flake8 Linter` jobs.
- `.bandit`, `.flake8` — generated linter config (also the detection files variables.sh uses to enable those linters).
- `.gitignore` — generated Python/PyCharm template sections.

`tests/action_contracts.py` was verified clean against both new linters locally (`flake8`: pass; `bandit`: "No issues identified").

## Types of changes

- [ ] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [x] Build or security update (updates dependencies, libraries, or security patches)
- [ ] Code style or documentation update (formatting, renaming, or documentation changes)
- [x] Other (please describe): regenerated github-build output to match applied branch protection

## Checklist

- [ ] Unit tests added to validate my fix/feature
- [x] I have manually tested my change
- [x] I did not add automation test. Why ?: files are github-build-generated config/workflow output; the added Bandit/Flake8 jobs are themselves CI automation and were verified clean locally against tests/action_contracts.py
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] \`readme.md\` includes sections on introduction, installation, usage, and contributing
- [ ] \`docs/architecture.md\` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified

## Further comments (if required)

Operational note for the reviewer: `master` branch protection was *already* updated by the github-build run to require `Python Bandit Linter` and `Python Flake8 Linter`, but the jobs that produce them only exist in this PR's regenerated `build.yml`. Until this merges, ci-actions PRs may sit unmergeable waiting on those two checks. This PR should be merged promptly to restore consistency. This PR itself produces the checks (the `.bandit`/`.flake8` files make variables.sh enable them on its own branch), so it can satisfy its own required checks.