### PR TITLE
Remove tj-actions/bandit supply-chain risk and fix axios vulnerable floor

### DIFF
--- a/linters/bandit/action.yml
+++ b/linters/bandit/action.yml
@@ -35,11 +35,23 @@ runs:
         lfs: true
         submodules: recursive
 
-    # https://github.com/marketplace/actions/bandit-security-linter
-    - name: Bandit
-      uses: tj-actions/bandit@v5
+    # https://github.com/marketplace/actions/setup-python
+    - name: Setup Python
+      uses: actions/setup-python@v6
       if: ${{ steps.check.outputs.continue == 'true' }}
       with:
-        targets: "."
-        # https://github.com/PyCQA/bandit
-        options: "-ll --ini .bandit --silent"
+        python-version: '3.x'
+
+    # https://github.com/PyCQA/bandit
+    # Installed directly rather than via tj-actions/bandit: the tj-actions org
+    # was compromised (CVE-2025-30066), so we avoid that supply-chain path and
+    # mirror how flake8/semgrep are installed in this repo.
+    - name: Install bandit
+      shell: bash
+      if: ${{ steps.check.outputs.continue == 'true' }}
+      run: pip install bandit
+
+    - name: Run bandit
+      shell: bash
+      if: ${{ steps.check.outputs.continue == 'true' }}
+      run: bandit -ll --ini .bandit --silent .

--- a/slack/package-lock.json
+++ b/slack/package-lock.json
@@ -10,7 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@actions/core": "^2.0.3",
-        "axios": "^1.7.9"
+        "axios": "^1.16.0"
       },
       "devDependencies": {
         "@vercel/ncc": "^0.38.4",

--- a/slack/package.json
+++ b/slack/package.json
@@ -18,7 +18,7 @@
   "license": "ISC",
   "dependencies": {
     "@actions/core": "^2.0.3",
-    "axios": "^1.7.9"
+    "axios": "^1.16.0"
   },
   "devDependencies": {
     "@vercel/ncc": "^0.38.4",


### PR DESCRIPTION
## Summary

Two dependency-security fixes from the code review. The Python Bandit linter ran via `tj-actions/bandit@v5`, and the `tj-actions` org was compromised in CVE-2025-30066 (attackers force-pushed tags), degrading trust in anything under it. Separately, the slack action's `axios` floor still permitted versions with known HIGH CVEs even though the lockfile resolved a patched build.

**Key changes:**

- `linters/bandit/action.yml` (DEP-002 / SEC-001): replace `tj-actions/bandit@v5` with `actions/setup-python@v6` + `pip install bandit` + a direct `bandit -ll --ini .bandit --silent .` run, mirroring how `flake8`/`semgrep` are already installed in this repo. Behaviour and options are preserved; the third-party action is no longer in the trust chain.
- `slack/package.json` + `slack/package-lock.json` (DEP-004): raise the `axios` floor from `^1.7.9` to `^1.16.0`. `^1.7.9` permitted 1.7.9–1.8.1 (CVE-2025-27152, SSRF) and <1.12.1 (CVE-2025-58754, DoS); a clean `npm install` without the lockfile could have landed on a vulnerable version. Installed version is unchanged (1.16.1), so the bundle is byte-identical and `.soup.json` (which records 1.16.1) stays accurate.

Verified: `yamllint` clean; the new `bandit` command runs clean and exits 0 against the repo; slack suite 27/27 passing; `dist/` rebuild deterministic (pretest stays green).

## Types of changes

- [ ] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [x] Build or security update (updates dependencies, libraries, or security patches)
- [ ] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

- [ ] Unit tests added to validate my fix/feature
- [x] I have manually tested my change
- [x] I did not add automation test. Why ?: dependency/CI-config change with no new code paths; verified by running the new bandit command (clean, exit 0), the slack jest suite (27/27), and confirming the dist bundle is unchanged
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] \`readme.md\` includes sections on introduction, installation, usage, and contributing
- [ ] \`docs/architecture.md\` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [x] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified