### PR TITLE
QUAL-007 eslint-version input, BUG-018 GPG retry, BC-002/BC-003 docs

### DIFF
--- a/linters/_lib/recv_gpg_key.sh
+++ b/linters/_lib/recv_gpg_key.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+# Fetch a GPG public key with retries and keyserver fallback.
+#
+# Usage (from a composite action step):
+#   run: bash "${GITHUB_ACTION_PATH}/../_lib/recv_gpg_key.sh" <KEY_ID_OR_FINGERPRINT>
+#
+# keyserver.ubuntu.com is well known to be slow / intermittently unavailable,
+# which made the pmd/phpcs linters flaky. Try several keyservers, a few times,
+# before failing the step with an actionable message.
+
+set -euo pipefail
+
+key="${1:?usage: recv_gpg_key.sh KEY_ID_OR_FINGERPRINT}"
+keyservers=(
+  hkps://keyserver.ubuntu.com
+  hkps://keys.openpgp.org
+  hkps://pgp.mit.edu
+)
+
+for attempt in 1 2 3; do
+  for keyserver in "${keyservers[@]}"; do
+    if gpg --keyserver "${keyserver}" --recv-keys "${key}"; then
+      echo "Imported GPG key ${key} from ${keyserver} (attempt ${attempt})"
+      exit 0
+    fi
+    echo "gpg --recv-keys ${key} from ${keyserver} failed (attempt ${attempt})" >&2
+  done
+  sleep $(( attempt * 5 ))
+done
+
+echo "::error::Failed to import GPG key ${key} from any keyserver after 3 attempts" >&2
+exit 1

--- a/linters/eslint/action.yml
+++ b/linters/eslint/action.yml
@@ -13,6 +13,10 @@ inputs:
     description: 'github token'
     required: false
     default: ${{ github.token }}
+  eslint-version:
+    description: 'ESLint version to install. Pinned to v8.x by default - v9 (flat config) is incompatible with legacy frontend JS (jQuery, etc.)'
+    required: false
+    default: '8.57.0'
 
 runs:
   using: "composite"
@@ -47,8 +51,9 @@ runs:
       shell: bash
       env:
         GITHUB_TOKEN: ${{ inputs.github-token }}
+        ESLINT_VERSION: ${{ inputs.eslint-version }}
       if: ${{ steps.check.outputs.continue == 'true' }}
-      run: npm install eslint@8.57.0  # Pinned to v8.x - v9 is incompatible with legacy frontend JS (jQuery, etc.)
+      run: npm install "eslint@${ESLINT_VERSION}"
 
     # https://github.com/marketplace/actions/run-eslint-with-reviewdog
     - name: Run ESLint with Reviewdog

--- a/linters/phpcs/action.yml
+++ b/linters/phpcs/action.yml
@@ -72,7 +72,7 @@ runs:
         GITHUB_TOKEN: ${{ inputs.github-token }}
         PHP_CS_FIXER_VERSION: ${{ inputs.php-cs-fixer-version }}
       run: |
-        gpg --keyserver hkps://keyserver.ubuntu.com --recv-keys E82B2FB314E9906E
+        bash "${GITHUB_ACTION_PATH}/../_lib/recv_gpg_key.sh" E82B2FB314E9906E
         if [ "${PHP_CS_FIXER_VERSION}" == "latest" ] ;then
           curl -L https://cs.symfony.com/download/php-cs-fixer-v3.phar -o php-cs-fixer
           curl -L https://cs.symfony.com/download/php-cs-fixer-v3.phar.asc -o php-cs-fixer.asc

--- a/linters/pmd/action.yml
+++ b/linters/pmd/action.yml
@@ -64,7 +64,7 @@ runs:
         echo "Installing PMD version: ${PMD_VERSION}"
         wget -q -O /opt/pmd.zip "https://github.com/pmd/pmd/releases/download/pmd_releases%2F${PMD_VERSION}/pmd-dist-${PMD_VERSION}-bin.zip"
         wget -q -O /opt/pmd.zip.asc "https://github.com/pmd/pmd/releases/download/pmd_releases%2F${PMD_VERSION}/pmd-dist-${PMD_VERSION}-bin.zip.asc"
-        gpg --keyserver hkps://keyserver.ubuntu.com --recv-keys 98313B2644E62EA447F7C58C08AACF8B0D441047
+        bash "${GITHUB_ACTION_PATH}/../_lib/recv_gpg_key.sh" 98313B2644E62EA447F7C58C08AACF8B0D441047
         gpg --verify /opt/pmd.zip.asc /opt/pmd.zip
         unzip -q -d /opt /opt/pmd.zip
         rm -f /opt/pmd.zip /opt/pmd.zip.asc

--- a/slack/README.md
+++ b/slack/README.md
@@ -2,6 +2,13 @@
 
 This action sends action status to Slack.
 
+## Requirements
+
+This action runs on the GitHub Actions **Node 24** runtime
+(`runs.using: 'node24'`). GitHub-hosted runners include it; **self-hosted
+runners must have Node 24 installed**, otherwise the action fails to start.
+Track GitHub's runtime deprecation schedule before bumping.
+
 ## Inputs
 
 ```yml

--- a/variables/README.md
+++ b/variables/README.md
@@ -66,6 +66,20 @@ outputs:
     value: ${{ steps.variables.outputs.LINTERS }}
 ```
 
+### Output contract (stability)
+
+These 15 outputs are a **public contract** consumed by every downstream
+composite action and by `slack`. Note in particular:
+
+- The boolean-style flags (`DEPLOY_ON_*`, `DEPLOY_MACOS/TVOS`, `SKIP_*`,
+  `UPDATE_PACKAGES`) are the **strings** `'1'` (set) or `'0'` (unset), not
+  real booleans — consumers compare with `== '1'`.
+- `DEPLOY_OPTIONS` is a free-form string and may be empty.
+
+Renaming or removing an output, or changing the `'0'`/`'1'` semantics, is a
+**breaking change** and must be released as a major version bump (use the
+floating `v1`/`v2` tags deliberately).
+
 ## Commit Message Triggers
 
 The variables action parses commit messages and tag annotations for special trigger keywords. Include these in your commit message or tag to control workflow behavior:


### PR DESCRIPTION
## Summary

Four code-review fixes: make the ESLint pin overridable, harden the flaky GPG key fetch in the pmd/phpcs linters, and document two implicit contracts (the slack Node runtime and the variables output stability).

**Key changes:**

- **QUAL-007** (`linters/eslint/action.yml`): add an `eslint-version` input (default `8.57.0`, with the legacy-jQuery rationale in its description) and install via `eslint@${ESLINT_VERSION}` (passed through `env:`). Consumers on ESLint 9 can now override it instead of being hard-pinned.
- **BUG-018** (`linters/_lib/recv_gpg_key.sh`, new; used by `linters/pmd/action.yml` and `linters/phpcs/action.yml`): replace the single `gpg --keyserver hkps://keyserver.ubuntu.com --recv-keys` call with a shared helper that retries across `keyserver.ubuntu.com`, `keys.openpgp.org`, and `pgp.mit.edu` (3 attempts, backoff) and fails with an actionable message. Mirrors the shared-script pattern from `_lib/check_enabled.sh`.
- **BC-002** (`slack/README.md`): add a Requirements section documenting the `node24` runtime — self-hosted runners must have Node 24.
- **BC-003** (`variables/README.md`): document the 15 outputs as a public contract — the `'0'`/`'1'` string semantics of the flags and that renaming/removing an output or changing those semantics is a breaking change requiring a major bump.

Verified: `yamllint` (repo config) clean on the three action.yml; `shellcheck` clean on the new script; `markdownlint-cli2` 0 errors; keyserver-fallback path simulated (ubuntu fails → openpgp succeeds → exit 0, no wasted retries).

## Types of changes

- [x] Bugfix (fixes an issue)
- [x] New feature (adds functionality)
- [ ] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [ ] Build or security update (updates dependencies, libraries, or security patches)
- [x] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

- [ ] Unit tests added to validate my fix/feature
- [x] I have manually tested my change
- [x] I did not add automation test. Why ?: config/doc + shell-helper change; no composite-action test harness for these paths (the smoke harness covers action load), the GPG helper was validated via shellcheck and a stubbed keyserver-fallback simulation
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] \`readme.md\` includes sections on introduction, installation, usage, and contributing
- [ ] \`docs/architecture.md\` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified