### PR TITLE
BUG-022 guard cache-dir capture, TEST-004 run variables.sh as a subprocess

### DIFF
--- a/linters/phpstan/action.yml
+++ b/linters/phpstan/action.yml
@@ -90,7 +90,10 @@ runs:
       env:
         GITHUB_TOKEN: ${{ inputs.github-token }}
       if: ${{ inputs.php-version != 'none' }}
-      run: echo "dir=$(composer config cache-files-dir)" >> "${GITHUB_OUTPUT}"
+      run: |
+        dir="$(composer config cache-files-dir)" || { echo "::error::composer is not available - cannot resolve the Composer cache directory"; exit 1; }
+        [ -n "$dir" ] || { echo "::error::composer config cache-files-dir returned empty"; exit 1; }
+        echo "dir=$dir" >> "${GITHUB_OUTPUT}"
     - name: Cache - Composer
       uses: actions/cache@v5
       if: ${{ steps.check.outputs.continue == 'true' }}

--- a/setup/action.yml
+++ b/setup/action.yml
@@ -690,7 +690,10 @@ runs:
       if: ${{ inputs.php-version != 'none' || steps.detect-versions.outputs.php-file }}
       env:
         GITHUB_TOKEN: ${{ inputs.github-token }}
-      run: echo "dir=$(composer config cache-files-dir)" >> "${GITHUB_OUTPUT}"
+      run: |
+        dir="$(composer config cache-files-dir)" || { echo "::error::composer is not available - cannot resolve the Composer cache directory"; exit 1; }
+        [ -n "$dir" ] || { echo "::error::composer config cache-files-dir returned empty"; exit 1; }
+        echo "dir=$dir" >> "${GITHUB_OUTPUT}"
     - name: Cache - Composer
       uses: actions/cache@v5
       if: ${{ inputs.php-version != 'none' || steps.detect-versions.outputs.php-file }}
@@ -721,7 +724,10 @@ runs:
       if: ${{ inputs.python-version != 'none' || steps.detect-versions.outputs.python-file }}
       env:
         GITHUB_TOKEN: ${{ inputs.github-token }}
-      run: echo "dir=$(pip cache dir)" >> "${GITHUB_OUTPUT}"
+      run: |
+        dir="$(pip cache dir)" || { echo "::error::pip is not available - cannot resolve the pip cache directory"; exit 1; }
+        [ -n "$dir" ] || { echo "::error::pip cache dir returned empty"; exit 1; }
+        echo "dir=$dir" >> "${GITHUB_OUTPUT}"
     - name: Cache - PIP
       uses: actions/cache@v5
       if: ${{ inputs.python-version != 'none' || steps.detect-versions.outputs.python-file }}

--- a/variables/tests/variables.bats
+++ b/variables/tests/variables.bats
@@ -598,60 +598,42 @@ teardown() {
 }
 
 # ============================================================================
-# Main body: GITHUB_ENV and GITHUB_OUTPUT writing tests
+# Main body: end-to-end subprocess run of variables.sh
 # ============================================================================
 
-@test "variables are written to GITHUB_ENV and GITHUB_OUTPUT" {
-  export COMMIT_MESSAGE="Deploy #beta-deploy"
-  export TAG=""
+@test "running variables.sh resolves triggers and writes GITHUB_ENV/OUTPUT" {
+  # Drive the real main() as a subprocess against a throwaway git repo, so the
+  # actual sequencing (trigger resolution + the GITHUB_ENV/OUTPUT write loop)
+  # is exercised rather than a re-implementation of it.
+  local repo="${TEST_DIR}/repo"
+  mkdir -p "${repo}"
+  (
+    cd "${repo}" || exit 1
+    git init -q
+    git config user.email test@example.com
+    git config user.name test
+    echo x > file.txt
+    git add file.txt
+    git commit -q -m "Test commit #beta-deploy #skip-tests"
+  )
 
-  # Set all flags as the main body does
-  set_flag_from_trigger DEPLOY_ON_BETA "beta-deploy"
-  set_flag_from_trigger DEPLOY_ON_RC "rc-deploy"
-  set_flag_from_trigger DEPLOY_MACOS "macos"
-  set_flag_from_trigger DEPLOY_TVOS "tvos"
-  set_flag_from_trigger SKIP_LICENSES "skip-licenses"
-  set_flag_from_trigger SKIP_LINTERS "skip-linters"
-  set_flag_from_trigger SKIP_TESTS "skip-tests"
-  set_flag_from_trigger UPDATE_PACKAGES "update-packages"
+  run bash -c "cd '${repo}' && \
+    GITHUB_REF=refs/heads/feature GITHUB_HEAD_REF=feature \
+    GITHUB_RUN_NUMBER=100 GITHUB_ENV='${GITHUB_ENV}' GITHUB_OUTPUT='${GITHUB_OUTPUT}' \
+    bash '${BATS_TEST_DIRNAME}/../variables.sh'"
 
-  DEPLOY_ON_PROD=0
-  if on_prod && [ "${TAG}" != "" ]; then
-    DEPLOY_ON_PROD=1
-  fi
+  [ "${status}" -eq 0 ]
 
-  DEPLOY_OPTIONS=""
-  if deploy_options; then
-    DEPLOY_OPTIONS="$(echo "${COMMIT_MESSAGE}" | sed -n 's/.*#deploy-options=\([^ ]*\).*/\1/p')"
-  fi
-
-  if skip_all; then
-    SKIP_LICENSES=1
-    SKIP_LINTERS=1
-    SKIP_TESTS=1
-  fi
-
-  LINTERS=""
-  BUILD_NAME="test-build"
-  BUILD_VERSION="test-version"
-  MODIFIED_GITHUB_RUN_NUMBER=15100
-
-  # Write to GITHUB_ENV and GITHUB_OUTPUT as the main body does
-  for github in BUILD_NAME BUILD_VERSION COMMIT_MESSAGE MODIFIED_GITHUB_RUN_NUMBER DEPLOY_ON_BETA DEPLOY_ON_RC DEPLOY_ON_PROD DEPLOY_MACOS DEPLOY_TVOS DEPLOY_OPTIONS SKIP_LICENSES SKIP_LINTERS SKIP_TESTS UPDATE_PACKAGES LINTERS; do
-    echo "${github}=${!github}" >> "${GITHUB_ENV}"
-    echo "${github}=${!github}" >> "${GITHUB_OUTPUT}"
-  done
-
-  # Verify GITHUB_ENV contents
-  grep -q "DEPLOY_ON_BETA=1" "${GITHUB_ENV}"
-  grep -q "DEPLOY_ON_RC=0" "${GITHUB_ENV}"
-  grep -q "DEPLOY_ON_PROD=0" "${GITHUB_ENV}"
-  grep -q "SKIP_LICENSES=0" "${GITHUB_ENV}"
-  grep -q "BUILD_NAME=test-build" "${GITHUB_ENV}"
-  grep -q "LINTERS=" "${GITHUB_ENV}"
-
-  # Verify GITHUB_OUTPUT contents
+  # Values resolved by the real script from the commit-message triggers
   grep -q "DEPLOY_ON_BETA=1" "${GITHUB_OUTPUT}"
+  grep -q "SKIP_TESTS=1" "${GITHUB_OUTPUT}"
   grep -q "DEPLOY_ON_RC=0" "${GITHUB_OUTPUT}"
+  grep -q "DEPLOY_ON_PROD=0" "${GITHUB_OUTPUT}"
   grep -q "MODIFIED_GITHUB_RUN_NUMBER=15100" "${GITHUB_OUTPUT}"
+  grep -q "COMMIT_MESSAGE=Test commit #beta-deploy #skip-tests" "${GITHUB_OUTPUT}"
+  grep -qE "BUILD_NAME=feature-.+" "${GITHUB_OUTPUT}"
+
+  # Same content mirrored to GITHUB_ENV
+  grep -q "DEPLOY_ON_BETA=1" "${GITHUB_ENV}"
+  grep -q "SKIP_TESTS=1" "${GITHUB_ENV}"
 }


### PR DESCRIPTION
## Summary

Two Medium code-review findings. A failed `composer`/`pip` cache-dir lookup was silently written as an empty path (breaking `actions/cache` later with a confusing error), and one bats test re-implemented `variables.sh`'s main body instead of executing it.

**Key changes:**

- **BUG-022** (`setup/action.yml` ×2, `linters/phpstan/action.yml` ×1): replace `run: echo "dir=$(composer config cache-files-dir)" >> "$GITHUB_OUTPUT"` (and the `pip cache dir` equivalent) with a guarded block that fails fast via `::error::` if the tool is missing or the directory is empty, instead of writing `dir=` and letting `actions/cache@v5` fail far from the cause.
- **TEST-004** (`variables/tests/variables.bats`): the "variables are written to GITHUB_ENV and GITHUB_OUTPUT" test re-created `main()`'s flag-resolution and write loop inline and asserted on its own copy. Replaced it with a real subprocess run of `variables.sh` against a throwaway git repo (commit message carrying `#beta-deploy #skip-tests`), asserting the resolved values in the real `GITHUB_ENV`/`GITHUB_OUTPUT`.

Verified: `yamllint` (repo config) clean; `tests/action_contracts.py` 28/28; full bats suite 65/65 (the rewritten test exercises the real script).

## Types of changes

- [x] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [x] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [ ] Build or security update (updates dependencies, libraries, or security patches)
- [ ] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

- [x] Unit tests added to validate my fix/feature
- [x] I have manually tested my change
- [ ] I did not add automation test. Why ?:
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] \`readme.md\` includes sections on introduction, installation, usage, and contributing
- [ ] \`docs/architecture.md\` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified