### PR TITLE
Test codedeploy/deploy failure paths (TEST-001); document eslint-version input (DOC-001)

### DIFF
--- a/codedeploy/deploy/action.yml
+++ b/codedeploy/deploy/action.yml
@@ -57,45 +57,4 @@ runs:
         S3_KEY: ${{ inputs.s3-key }}
         DEPLOYMENT_STRATEGY: ${{ inputs.deployment-strategy }}
         MONITOR_TIMEOUT_MINUTES: ${{ inputs.monitor-timeout-minutes }}
-      run: |
-        set -euo pipefail
-
-        deployment=$(aws deploy create-deployment --application-name "${APPLICATION_NAME}" --deployment-config-name "${DEPLOYMENT_STRATEGY}" --deployment-group-name "${DEPLOYMENT_GROUP_NAME}" --description "Deploy build ${GITHUB_RUN_NUMBER} via Github Actions" --s3-location "bucket=${S3_BUCKET},bundleType=zip,key=${S3_KEY}" --query 'deploymentId' --output text)
-        echo "Deployment ID=${deployment}"
-
-        poll_interval=5
-        max_iterations=$(( MONITOR_TIMEOUT_MINUTES * 60 / poll_interval ))
-
-        for (( counter = 1; counter <= max_iterations; counter++ )); do
-          # Tolerate transient CodeDeploy API errors so a single blip does not
-          # abort monitoring of an otherwise healthy deployment.
-          status=$(aws deploy get-deployment --deployment-id "${deployment}" --query 'deploymentInfo.status' --output text 2>/dev/null || echo "Unknown")
-
-          case ${status} in
-            Succeeded)
-            echo "Deployment succeeded"
-            exit 0
-            ;;
-
-            Failed|Stopped)
-            # Fail the step so downstream jobs and notifications see the failure.
-            echo "::error::CodeDeploy deployment ${status} (id=${deployment})"
-            exit 1
-            ;;
-
-            *)
-            # Anything else (Created, Queued, InProgress, Ready, Baking, ...) is
-            # non-terminal. "Ready" in blue/green still has BlockTraffic /
-            # AllowTraffic / TerminateBlueInstances phases that can fail, so we
-            # keep polling until a true terminal state is observed.
-            echo "Deployment status=${status}... (${counter}/${max_iterations})"
-            sleep "${poll_interval}"
-            ;;
-          esac
-        done
-
-        # Timeout is a real failure signal: the deployment never reached a
-        # terminal state within the monitoring window. Surface it instead of
-        # reporting a green build for an in-flight or failed deployment.
-        echo "::error::Deployment ${deployment} did not reach a terminal state within ${MONITOR_TIMEOUT_MINUTES} minutes. Check the AWS CodeDeploy console."
-        exit 1
+      run: bash "${GITHUB_ACTION_PATH}/deploy.sh"

--- a/codedeploy/deploy/deploy.sh
+++ b/codedeploy/deploy/deploy.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+
+# CodeDeploy deployment driver, extracted from action.yml so the failure /
+# timeout / transient-error classification can be exercised by the bats suite
+# (a regression that swallowed a Failed status would otherwise produce a
+# false-green deployment with nothing to catch it). The functions below are
+# sourced by tests/deploy.bats; main() only runs when invoked directly.
+
+# Seconds between get-deployment polls. Overridable so the test suite can keep
+# the loop fast; defaults to the original hard-coded interval.
+POLL_INTERVAL="${POLL_INTERVAL:-5}"
+
+# Create the CodeDeploy deployment and echo its id. Kept as a function so the
+# test suite can stub `aws` and assert the create arguments.
+function create_deployment()
+{
+  aws deploy create-deployment \
+    --application-name "${APPLICATION_NAME}" \
+    --deployment-config-name "${DEPLOYMENT_STRATEGY}" \
+    --deployment-group-name "${DEPLOYMENT_GROUP_NAME}" \
+    --description "Deploy build ${GITHUB_RUN_NUMBER} via Github Actions" \
+    --s3-location "bucket=${S3_BUCKET},bundleType=zip,key=${S3_KEY}" \
+    --query 'deploymentId' --output text
+}
+
+# Poll a deployment to a terminal state.
+# Usage: poll_deployment <deployment-id> <max-iterations>
+# Returns: 0 = Succeeded, 1 = Failed/Stopped, 2 = timed out before terminal.
+function poll_deployment()
+{
+  local deployment="$1"
+  local max_iterations="$2"
+  local counter status
+
+  for (( counter = 1; counter <= max_iterations; counter++ )); do
+    # Tolerate transient CodeDeploy API errors so a single blip does not
+    # abort monitoring of an otherwise healthy deployment.
+    status=$(aws deploy get-deployment --deployment-id "${deployment}" --query 'deploymentInfo.status' --output text 2>/dev/null || echo "Unknown")
+
+    case ${status} in
+      Succeeded)
+      echo "Deployment succeeded"
+      return 0
+      ;;
+
+      Failed|Stopped)
+      # Fail the step so downstream jobs and notifications see the failure.
+      echo "::error::CodeDeploy deployment ${status} (id=${deployment})"
+      return 1
+      ;;
+
+      *)
+      # Anything else (Created, Queued, InProgress, Ready, Baking, ...) is
+      # non-terminal. "Ready" in blue/green still has BlockTraffic /
+      # AllowTraffic / TerminateBlueInstances phases that can fail, so we
+      # keep polling until a true terminal state is observed.
+      echo "Deployment status=${status}... (${counter}/${max_iterations})"
+      sleep "${POLL_INTERVAL}"
+      ;;
+    esac
+  done
+
+  # Timeout is a real failure signal: the deployment never reached a
+  # terminal state within the monitoring window. Surface it instead of
+  # reporting a green build for an in-flight or failed deployment.
+  echo "::error::Deployment ${deployment} did not reach a terminal state within ${MONITOR_TIMEOUT_MINUTES} minutes. Check the AWS CodeDeploy console."
+  return 2
+}
+
+# Create the deployment then monitor it to a terminal state. Wrapped in a
+# function so the test suite can source this file for its helpers without
+# launching a deployment.
+function main()
+{
+  # Fail fast on any command error, unset variable, or failed pipe so a
+  # broken create-deployment or environment surfaces instead of silently
+  # proceeding. Scoped to main so sourcing this file for the test suite does
+  # not change the caller's shell options.
+  set -euo pipefail
+
+  local deployment max_iterations exit_code
+
+  deployment=$(create_deployment)
+  echo "Deployment ID=${deployment}"
+
+  max_iterations=$(( MONITOR_TIMEOUT_MINUTES * 60 / POLL_INTERVAL ))
+
+  # Map terminal/timeout to a non-zero step exit; both 1 and 2 are failures.
+  exit_code=0
+  poll_deployment "${deployment}" "${max_iterations}" || exit_code=$?
+  if [ "${exit_code}" -ne 0 ]; then
+    exit 1
+  fi
+}
+
+# Only run main when executed directly (via the action's bash invocation),
+# not when sourced by the bats test suite.
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  main
+fi

--- a/codedeploy/tests/deploy.bats
+++ b/codedeploy/tests/deploy.bats
@@ -1,0 +1,167 @@
+#!/usr/bin/env bats
+
+# Setup: source the real deploy.sh for its function definitions. The script
+# guards its main body behind `[[ "${BASH_SOURCE[0]}" == "${0}" ]]`, so sourcing
+# here loads create_deployment / poll_deployment without launching a real AWS
+# deployment.
+setup() {
+  export APPLICATION_NAME="app"
+  export DEPLOYMENT_GROUP_NAME="group"
+  export DEPLOYMENT_STRATEGY="CodeDeployDefault.OneAtATime"
+  export S3_BUCKET="bucket"
+  export S3_KEY="key.zip"
+  export GITHUB_RUN_NUMBER=100
+  export MONITOR_TIMEOUT_MINUTES=30
+  # Non-zero so main()'s `max_iterations = MINUTES*60/POLL_INTERVAL` never
+  # divides by zero; the loop is kept instant by the stubbed sleep instead.
+  export POLL_INTERVAL=1
+
+  source "${BATS_TEST_DIRNAME}/../deploy/deploy.sh"
+
+  # Never actually sleep during the polling loop (sourced unit tests).
+  sleep() { :; }
+}
+
+# Build a throwaway PATH dir with fake `aws` / `sleep` executables so the
+# end-to-end tests can drive the real deploy.sh as a subprocess (mirroring the
+# variables.bats subprocess pattern) rather than a re-implementation.
+make_fake_bin() {
+  local create_out="$1" get_out="$2"
+  local bin="${BATS_TEST_TMPDIR}/bin"
+  mkdir -p "${bin}"
+  cat > "${bin}/aws" <<EOF
+#!/usr/bin/env bash
+if [ "\$2" = "create-deployment" ]; then echo "${create_out}"; else echo "${get_out}"; fi
+EOF
+  printf '#!/usr/bin/env bash\nexit 0\n' > "${bin}/sleep"
+  chmod +x "${bin}/aws" "${bin}/sleep"
+  echo "${bin}"
+}
+
+# ============================================================================
+# create_deployment
+# ============================================================================
+
+@test "create_deployment returns the deployment id from aws" {
+  aws() { echo "d-ABC123"; }
+  run create_deployment
+  [ "$status" -eq 0 ]
+  [ "$output" = "d-ABC123" ]
+}
+
+@test "create_deployment passes the build number in the description" {
+  # Echo the args so we can assert the create-deployment invocation shape.
+  aws() { echo "$*"; }
+  run create_deployment
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"create-deployment"* ]]
+  [[ "$output" == *"--application-name app"* ]]
+  [[ "$output" == *"Deploy build 100 via Github Actions"* ]]
+  [[ "$output" == *"bucket=bucket,bundleType=zip,key=key.zip"* ]]
+}
+
+# ============================================================================
+# poll_deployment: terminal states
+# ============================================================================
+
+@test "poll_deployment returns 0 when deployment Succeeded" {
+  aws() { echo "Succeeded"; }
+  run poll_deployment "d-1" 5
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Deployment succeeded"* ]]
+}
+
+@test "poll_deployment returns 1 when deployment Failed" {
+  aws() { echo "Failed"; }
+  run poll_deployment "d-1" 5
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"::error::CodeDeploy deployment Failed (id=d-1)"* ]]
+}
+
+@test "poll_deployment returns 1 when deployment Stopped" {
+  aws() { echo "Stopped"; }
+  run poll_deployment "d-1" 5
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"::error::CodeDeploy deployment Stopped (id=d-1)"* ]]
+}
+
+# ============================================================================
+# poll_deployment: non-terminal progression and transient errors
+# ============================================================================
+
+@test "poll_deployment keeps polling through non-terminal states then succeeds" {
+  # InProgress, then InProgress, then Succeeded across three polls.
+  cat > "${BATS_TEST_TMPDIR:-/tmp}/calls" <<< "0"
+  aws() {
+    local n
+    n=$(cat "${BATS_TEST_TMPDIR:-/tmp}/calls")
+    n=$(( n + 1 ))
+    echo "${n}" > "${BATS_TEST_TMPDIR:-/tmp}/calls"
+    if [ "${n}" -lt 3 ]; then echo "InProgress"; else echo "Succeeded"; fi
+  }
+  run poll_deployment "d-1" 5
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Deployment status=InProgress... (1/5)"* ]]
+  [[ "$output" == *"Deployment status=InProgress... (2/5)"* ]]
+  [[ "$output" == *"Deployment succeeded"* ]]
+}
+
+@test "poll_deployment tolerates a transient aws error then succeeds" {
+  cat > "${BATS_TEST_TMPDIR:-/tmp}/calls" <<< "0"
+  aws() {
+    local n
+    n=$(cat "${BATS_TEST_TMPDIR:-/tmp}/calls")
+    n=$(( n + 1 ))
+    echo "${n}" > "${BATS_TEST_TMPDIR:-/tmp}/calls"
+    # First call simulates an API failure (non-zero, no stdout): the script's
+    # `|| echo "Unknown"` must absorb it and keep polling.
+    if [ "${n}" -eq 1 ]; then return 255; fi
+    echo "Succeeded"
+  }
+  run poll_deployment "d-1" 5
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Deployment status=Unknown... (1/5)"* ]]
+  [[ "$output" == *"Deployment succeeded"* ]]
+}
+
+# ============================================================================
+# poll_deployment: timeout
+# ============================================================================
+
+@test "poll_deployment returns 2 and errors when it never reaches a terminal state" {
+  aws() { echo "InProgress"; }
+  run poll_deployment "d-1" 3
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"Deployment status=InProgress... (3/3)"* ]]
+  [[ "$output" == *"::error::Deployment d-1 did not reach a terminal state within 30 minutes"* ]]
+}
+
+# ============================================================================
+# End-to-end: main() maps a failed deployment to a non-zero step exit
+# ============================================================================
+
+@test "main exits 1 when the deployment Fails (no false-green)" {
+  local bin
+  bin=$(make_fake_bin "d-FAIL" "Failed")
+  run env PATH="${bin}:${PATH}" bash "${BATS_TEST_DIRNAME}/../deploy/deploy.sh"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"::error::CodeDeploy deployment Failed (id=d-FAIL)"* ]]
+}
+
+@test "main exits 0 when the deployment Succeeds" {
+  local bin
+  bin=$(make_fake_bin "d-OK" "Succeeded")
+  run env PATH="${bin}:${PATH}" bash "${BATS_TEST_DIRNAME}/../deploy/deploy.sh"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Deployment ID=d-OK"* ]]
+  [[ "$output" == *"Deployment succeeded"* ]]
+}
+
+@test "main exits 1 when the deployment times out" {
+  local bin
+  bin=$(make_fake_bin "d-SLOW" "InProgress")
+  run env PATH="${bin}:${PATH}" MONITOR_TIMEOUT_MINUTES=1 POLL_INTERVAL=1 \
+    bash "${BATS_TEST_DIRNAME}/../deploy/deploy.sh"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"did not reach a terminal state"* ]]
+}

--- a/linters/eslint/README.md
+++ b/linters/eslint/README.md
@@ -20,6 +20,10 @@ inputs:
     description: 'github token'
     required: false
     default: ${{ github.token }}
+  eslint-version:
+    description: 'ESLint version to install. Pinned to v8.x by default - v9 (flat config) is incompatible with legacy frontend JS (jQuery, etc.)'
+    required: false
+    default: '8.57.0'
 ```
 
 ## Example usage


### PR DESCRIPTION
## Summary

Addresses two findings from the deep code review. **TEST-001 (High):** the CodeDeploy deployment monitor (`Failed`/`Stopped`/timeout/transient-error classification) had zero behavioral coverage — a regression that swallowed a failed status would produce a false-green deployment with nothing to catch it. The poll loop is extracted verbatim from the inline `run:` block into a sourceable, testable `codedeploy/deploy/deploy.sh` (mirroring the existing `variables/variables.sh` pattern: function-scoped `set -euo pipefail`, `BASH_SOURCE` guard) and covered by an 11-test bats suite that stubs the `aws` CLI. **DOC-001 (Medium):** the `eslint-version` input existed in `linters/eslint/action.yml` but was undocumented in its README, the lone outlier among the linter actions.

Behavior is unchanged — the script reproduces the exact messages, exit codes, and polling semantics of the previous inline implementation. CI picks up the new suite automatically: the `codedeploy/.bats` marker is discovered by the `github-build` generator's `Dir.glob("*/.bats")` (same mechanism as `variables/.bats`), so the next `build.yml` regen emits a `Bats (codedeploy)` job. No hand-edit to the generated `build.yml`.

**Key changes:**

- Extract the CodeDeploy create + poll-to-terminal-state logic into `codedeploy/deploy/deploy.sh` with discrete `create_deployment` / `poll_deployment` / `main` functions
- Replace the inline `run:` block in `codedeploy/deploy/action.yml` with `bash "${GITHUB_ACTION_PATH}/deploy.sh"`
- Add `codedeploy/tests/deploy.bats` (11 tests: Succeeded/Failed/Stopped, non-terminal progression, transient-error tolerance, timeout, and end-to-end `main()` no-false-green via a fake `aws` on PATH)
- Add empty `codedeploy/.bats` generator marker so CI runs the suite
- Document the `eslint-version` input in `linters/eslint/README.md`

Verified locally: 11/11 codedeploy tests pass, `variables` bats suite still green (no regression), `action_contracts.py` clean (28/28), shellcheck/yamllint/markdownlint clean.

## Types of changes

- [x] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [x] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [ ] Build or security update (updates dependencies, libraries, or security patches)
- [x] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

- [x] Unit tests added to validate my fix/feature
- [x] I have manually tested my change
- [ ] I did not add automation test. Why ?:
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] `readme.md` includes sections on introduction, installation, usage, and contributing
- [ ] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified