### PR TITLE
Assert check_enabled.sh gate output in smoke linters job (TEST-008)

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -151,6 +151,35 @@ jobs:
       with:
         linters: ''
         ssh-key: ''
+    # The 19 invocations above only prove the actions load and run the gate;
+    # they would still pass green if check_enabled.sh were flipped to
+    # continue=true (checkout + reviewdog would simply run). Assert the gate
+    # output directly so a regression in the shared QUAL-001 gate fails here.
+    - name: Assert check_enabled.sh gate output
+      shell: bash
+      run: |
+        set -euo pipefail
+        gate="linters/_lib/check_enabled.sh"
+        run_gate() { # LINTERS_VALUE LINTER_NAME -> echoes continue=...
+          local out
+          out="$(mktemp)"
+          LINTERS="$1" GITHUB_OUTPUT="${out}" bash "${gate}" "$2"
+          cat "${out}"
+        }
+        # Disabled path (the path the smoke invocations above exercise): an
+        # empty list must resolve to continue=false.
+        got="$(run_gate '' ACTIONLINT)"
+        test "${got}" = 'continue=false' \
+          || { echo "::error::empty LINTERS should disable ACTIONLINT, got '${got}'"; exit 1; }
+        # Disabled path: a non-empty list that omits the linter -> continue=false.
+        got="$(run_gate 'SHELLCHECK' ACTIONLINT)"
+        test "${got}" = 'continue=false' \
+          || { echo "::error::ACTIONLINT absent from LINTERS should disable it, got '${got}'"; exit 1; }
+        # Enabled path: a list containing the linter -> continue=true.
+        got="$(run_gate 'ACTIONLINT SHELLCHECK' ACTIONLINT)"
+        test "${got}" = 'continue=true' \
+          || { echo "::error::ACTIONLINT present in LINTERS should enable it, got '${got}'"; exit 1; }
+        echo "check_enabled.sh gate OK (disabled, absent, enabled paths verified)"
 
   variables-smoke:
     name: Variables action


### PR DESCRIPTION
## Summary

The `linters-smoke` job invoked all 19 linter composite actions with an empty
`linters` list to exercise the shared QUAL-001 `check_enabled.sh` disabled
path, but asserted nothing about the outcome (TEST-008). Those invocations only
prove the actions load and run the gate — they would still pass green if
`check_enabled.sh` were flipped to `continue=true`, since the downstream
checkout and reviewdog steps would simply run. This adds a direct runtime
assertion of the gate's output so a regression in the shared gate fails the
smoke job, mirroring the existing `variables-smoke` job which already verifies
its outputs.

**Key changes:**

- Add an "Assert check_enabled.sh gate output" step to the `linters-smoke` job
  in `.github/workflows/smoke.yml`.
- Verify all three gate outcomes: empty list → `continue=false`, linter absent
  from a non-empty list → `continue=false`, and linter present → `continue=true`.
- Each case fails the job with a `::error::` annotation on an unexpected result.

## Types of changes

- [ ] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [ ] Build or security update (updates dependencies, libraries, or security patches)
- [ ] Code style or documentation update (formatting, renaming, or documentation changes)
- [x] Other (please describe): CI smoke-test hardening (adds a missing runtime assertion)

## Checklist

- [x] Unit tests added to validate my fix/feature
- [x] I have manually tested my change
- [ ] I did not add automation test. Why ?:
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] `readme.md` includes sections on introduction, installation, usage, and contributing
- [ ] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified