### PR TITLE
Anchor tag-ref detection in variables.sh to refs/tags/ prefix

### DIFF
--- a/variables/tests/variables.bats
+++ b/variables/tests/variables.bats
@@ -637,3 +637,33 @@ teardown() {
   grep -q "DEPLOY_ON_BETA=1" "${GITHUB_ENV}"
   grep -q "SKIP_TESTS=1" "${GITHUB_ENV}"
 }
+
+@test "branch ref containing 'tags' is not misrouted to the tag path" {
+  # Regression: GITHUB_REF carries the substring 'tags' but is a branch, not
+  # refs/tags/*. The old unanchored `grep tags` routed this through the tag path,
+  # which ran a tag fetch and produced an empty COMMIT_MESSAGE / slash-mangled
+  # BUILD_NAME. The anchored check must keep it on the branch path.
+  local repo="${TEST_DIR}/repo"
+  mkdir -p "${repo}"
+  (
+    cd "${repo}" || exit 1
+    git init -q
+    git config user.email test@example.com
+    git config user.name test
+    echo x > file.txt
+    git add file.txt
+    git commit -q -m "Branch build commit"
+  )
+
+  run bash -c "cd '${repo}' && \
+    GITHUB_REF=refs/heads/feature/tags-cleanup GITHUB_HEAD_REF='' \
+    GITHUB_SHA=HEAD GITHUB_RUN_NUMBER=100 \
+    GITHUB_ENV='${GITHUB_ENV}' GITHUB_OUTPUT='${GITHUB_OUTPUT}' \
+    bash '${BATS_TEST_DIRNAME}/../variables.sh'"
+
+  [ "${status}" -eq 0 ]
+  grep -q "COMMIT_MESSAGE=Branch build commit" "${GITHUB_OUTPUT}"
+  grep -qE "BUILD_NAME=feature_tags-cleanup-.+" "${GITHUB_OUTPUT}"
+  # BUILD_NAME must not contain a slash (a slash means the tag path mangled it).
+  ! grep -E "^BUILD_NAME=.*/" "${GITHUB_OUTPUT}"
+}

--- a/variables/variables.sh
+++ b/variables/variables.sh
@@ -110,7 +110,11 @@ function main()
   # between a tag build, a PR-head build, and a branch build. BUILD_NAME /
   # BUILD_VERSION are then derived identically for all three.
   TAG=""
-  if echo "${GITHUB_REF:-}" | grep tags &> /dev/null; then
+  # Anchored prefix match: a substring `grep tags` also matched branch refs that
+  # merely contain "tags" (e.g. refs/heads/feature/tags-cleanup), routing them
+  # through the tag path -> empty COMMIT_MESSAGE, slash-mangled BUILD_NAME, and a
+  # spurious tag fetch.
+  if [[ "${GITHUB_REF:-}" == refs/tags/* ]]; then
     TAG="${GITHUB_REF/refs\/tags\//}"
     SOURCE_REF="${TAG}"
     git fetch --depth=1 origin +refs/tags/*:refs/tags/*


### PR DESCRIPTION
## Summary

`variables.sh` decided whether a build is a tag build with an unanchored
`echo "${GITHUB_REF}" | grep tags`. Because that is a substring match, any
branch whose ref merely contains the literal `tags` — e.g.
`refs/heads/feature/tags-cleanup` or `refs/heads/hotfix-tags` — was routed
through the tag path. That produced a slash-mangled `BUILD_NAME`, an empty
`COMMIT_MESSAGE` (so commit-message deploy triggers silently disabled), a
spurious `git fetch` of all tags, and a non-empty `TAG` that could wrongly
satisfy the prod-deploy guard. This anchors the check to the `refs/tags/`
prefix so only real tag builds take the tag path.

**Key changes:**

- Replace the substring `grep tags` with an anchored `[[ "${GITHUB_REF:-}" == refs/tags/* ]]` check in `variables/variables.sh`.
- Add a bats regression test driving `main()` with `GITHUB_REF=refs/heads/feature/tags-cleanup`, asserting it stays on the branch path (real `COMMIT_MESSAGE`, slash-free `BUILD_NAME`).

## Types of changes

- [x] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [ ] Build or security update (updates dependencies, libraries, or security patches)
- [ ] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

- [x] Unit tests added to validate my fix/feature
- [x] I have manually tested my change
- [ ] I did not add automation test. Why ?:
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] `readme.md` includes sections on introduction, installation, usage, and contributing
- [ ] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified