### PR TITLE
Harden check_enabled.sh gate to whole-word linter matching

### DIFF
--- a/linters/_lib/check_enabled.sh
+++ b/linters/_lib/check_enabled.sh
@@ -14,7 +14,11 @@ set -euo pipefail
 
 linter_name="${1:?usage: check_enabled.sh LINTER_NAME}"
 
-if echo "${LINTERS:-}" | grep -- "${linter_name}" &> /dev/null; then
+# -w (whole word) + -F (fixed string) so a linter name can only match a complete
+# token in the space-separated list, never a substring of another. Without -wF a
+# future linter whose name is a substring of another (or of a LINTERS token)
+# would silently mis-enable.
+if echo "${LINTERS:-}" | grep -qwF -- "${linter_name}"; then
   echo "continue=true" >> "${GITHUB_OUTPUT}"
 else
   echo "continue=false" >> "${GITHUB_OUTPUT}"


### PR DESCRIPTION
## Summary

The shared linter-enabled gate (`check_enabled.sh`, used by all 19 linter
composite actions) tested membership with an unanchored `grep -- "${linter_name}"`,
a substring match against the space-separated `LINTERS` list. The 19 current
names don't overlap, so there is no live bug, but it is a latent footgun: a
future linter whose name is a substring of another (or of a `LINTERS` token)
would silently mis-enable. Switching to `grep -qwF` (whole-word, fixed-string)
makes a name match only a complete token. All 19 current names continue to
match exactly as before.

**Key changes:**

- Replace `grep -- "${linter_name}"` with `grep -qwF -- "${linter_name}"` in `linters/_lib/check_enabled.sh` (the `-q` also subsumes the old `&> /dev/null`).

## Types of changes

- [ ] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [ ] Build or security update (updates dependencies, libraries, or security patches)
- [ ] Code style or documentation update (formatting, renaming, or documentation changes)
- [x] Other (please describe): defensive hardening of the shared linter gate (no behavior change for current linters)

## Checklist

- [ ] Unit tests added to validate my fix/feature
- [x] I have manually tested my change
- [x] I did not add automation test. Why ?: behavior verified manually for all 19 names + substring edge cases; the linters-smoke job (PR #213) exercises this gate end-to-end in CI
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] `readme.md` includes sections on introduction, installation, usage, and contributing
- [ ] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified