### PR TITLE
Gate phpstan setup steps on the linter-enabled check

### DIFF
--- a/linters/phpstan/action.yml
+++ b/linters/phpstan/action.yml
@@ -66,7 +66,7 @@ runs:
     # install apt packages
     - name: Install APT Packages
       shell: bash
-      if: ${{ inputs.apt-packages != 'none' }}
+      if: ${{ inputs.apt-packages != 'none' && steps.check.outputs.continue == 'true' }}
       env:
         GITHUB_TOKEN: ${{ inputs.github-token }}
         APT_PACKAGES: ${{ inputs.apt-packages }}
@@ -89,7 +89,7 @@ runs:
       shell: bash
       env:
         GITHUB_TOKEN: ${{ inputs.github-token }}
-      if: ${{ inputs.php-version != 'none' }}
+      if: ${{ inputs.php-version != 'none' && steps.check.outputs.continue == 'true' }}
       run: |
         dir="$(composer config cache-files-dir)" || { echo "::error::composer is not available - cannot resolve the Composer cache directory"; exit 1; }
         [ -n "$dir" ] || { echo "::error::composer config cache-files-dir returned empty"; exit 1; }


### PR DESCRIPTION
## Summary

In `linters/phpstan/action.yml`, the "Install APT Packages" and "Cache -
Composer Location" steps gated only on their own inputs (`apt-packages != 'none'`
and `php-version != 'none'`, the latter defaulting to `8.2`) and not on the
shared linter-enabled gate. As a result, when PHPStan was disabled a consumer
that passed `apt-packages` would still run `apt-get`, and the composer
cache-location step would still run `composer config ...` — both doing work (and
the latter depending on `composer` being on the runner) for a linter that is
switched off. This adds `&& steps.check.outputs.continue == 'true'` to both
conditions so the steps run only when PHPStan is actually enabled, matching how
every other step in the action is gated.

**Key changes:**

- Gate "Install APT Packages" on `inputs.apt-packages != 'none' && steps.check.outputs.continue == 'true'`.
- Gate "Cache - Composer Location" on `inputs.php-version != 'none' && steps.check.outputs.continue == 'true'`.

## Types of changes

- [ ] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [ ] Build or security update (updates dependencies, libraries, or security patches)
- [ ] Code style or documentation update (formatting, renaming, or documentation changes)
- [x] Other (please describe): skip disabled-linter setup steps to avoid wasted CI work (no change when PHPStan is enabled)

## Checklist

- [ ] Unit tests added to validate my fix/feature
- [x] I have manually tested my change
- [x] I did not add automation test. Why ?: composite action.yml; validated by tests/action_contracts.py and the linters-smoke disabled-path job, which pins apt-packages/php-version to 'none' for phpstan
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] `readme.md` includes sections on introduction, installation, usage, and contributing
- [ ] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified