### PR TITLE
Bump Node to 26.2.0 and ignore coverage output in ESLint

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -3,7 +3,7 @@
     "node": true,
     "es2021": true
   },
-  "ignorePatterns": ["**/dist/**", "**/vendor/**", "**/node_modules/**", "**/Libraries/**", "**/Pods/**", "**/.build/**", "**/Carthage/**", "**/DerivedData/**", "**/venv/**", "**/.venv/**", "**/build/**", "**/target/**"],
+  "ignorePatterns": ["**/dist/**", "**/vendor/**", "**/node_modules/**", "**/Libraries/**", "**/Pods/**", "**/.build/**", "**/Carthage/**", "**/DerivedData/**", "**/venv/**", "**/.venv/**", "**/build/**", "**/target/**", "**/coverage/**"],
   "extends": ["eslint:recommended"],
   "parserOptions": {
     "ecmaVersion": "latest",

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ permissions:
   pull-requests: read
 env:
   NODE-CACHE: npm
-  NODE-VERSION: 26.1.0
+  NODE-VERSION: 26.2.0
 concurrency:
   group: build-${{github.ref}}
   cancel-in-progress: true


### PR DESCRIPTION
## Summary

Routine maintenance update bumping the CI Node.js version and excluding generated coverage output from ESLint linting.

**Key changes:**

- Bump `NODE-VERSION` from `26.1.0` to `26.2.0` in `.github/workflows/build.yml`
- Add `**/coverage/**` to the `ignorePatterns` in `.eslintrc.json` so generated coverage reports are not linted

## Types of changes

- [ ] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [x] Build or security update (updates dependencies, libraries, or security patches)
- [ ] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

- [ ] Unit tests added to validate my fix/feature
- [ ] I have manually tested my change
- [ ] I did not add automation test. Why ?:
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] `readme.md` includes sections on introduction, installation, usage, and contributing
- [ ] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified