### PR TITLE
Document shared linter _lib helpers in architecture.md

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -182,6 +182,14 @@ an authenticated `gh` on PATH.
 **Pattern:** Each linter action checks if it should run based on the `LINTERS`
 input variable, which is populated by the variables action.
 
+**Shared helpers (`linters/_lib/`):**
+
+- `check_enabled.sh`: invoked by every linter action via
+  `${GITHUB_ACTION_PATH}/../_lib/check_enabled.sh <NAME>` to gate execution on
+  whether `<NAME>` appears (as a whole word) in the `LINTERS` list
+- `recv_gpg_key.sh`: fetches a GPG public key with retries and keyserver
+  fallback (used by phpcs and pmd before signature verification)
+
 ### setup
 
 **Purpose:** Unified setup action for multiple language runtimes and services.
@@ -388,6 +396,8 @@ a newer upstream version, preserving the existing pin style.
 
 - phpcs: Downloads php-cs-fixer and verifies GPG signature before execution
 - pmd: Downloads PMD release and verifies GPG signature before execution
+- Public keys are fetched via the shared `linters/_lib/recv_gpg_key.sh` helper,
+  which retries across multiple keyservers to avoid flaky imports
 
 #### Code Analysis
 


### PR DESCRIPTION
## Summary

Documents the shared helper scripts under `linters/_lib/` in the architecture
reference so the docs reflect how linter actions gate execution and verify GPG
signatures.

**Key changes:**

- Add a "Shared helpers (`linters/_lib/`)" subsection describing `check_enabled.sh`
  (gates each linter action on the `LINTERS` list via `${GITHUB_ACTION_PATH}`) and
  `recv_gpg_key.sh` (fetches GPG keys with retries and keyserver fallback)
- Note in the GPG verification section that phpcs and pmd fetch public keys
  through the shared `recv_gpg_key.sh` helper to avoid flaky keyserver imports

## Types of changes

- [ ] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [ ] Build or security update (updates dependencies, libraries, or security patches)
- [x] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

- [ ] Unit tests added to validate my fix/feature
- [x] I have manually tested my change
- [x] I did not add automation test. Why ?: Documentation-only change; no code behavior modified
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] `readme.md` includes sections on introduction, installation, usage, and contributing
- [x] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified