### PR TITLE
Bump external action references

### DIFF
--- a/aws/action.yml
+++ b/aws/action.yml
@@ -37,7 +37,7 @@ runs:
 
     # https://github.com/marketplace/actions/configure-aws-credentials-action-for-github-actions
     - name: Configure AWS Credentials
-      uses: aws-actions/configure-aws-credentials@v5
+      uses: aws-actions/configure-aws-credentials@v6
       with:
         aws-access-key-id: ${{ inputs.aws-access-key-id }}
         aws-secret-access-key: ${{ inputs.aws-secret-access-key }}

--- a/codedeploy/deploy/action.yml
+++ b/codedeploy/deploy/action.yml
@@ -41,7 +41,7 @@ runs:
   steps:
     # https://github.com/marketplace/actions/configure-aws-credentials-action-for-github-actions
     - name: Configure AWS credentials
-      uses: aws-actions/configure-aws-credentials@v5
+      uses: aws-actions/configure-aws-credentials@v6
       with:
         aws-access-key-id: ${{ inputs.aws-access-key-id }}
         aws-secret-access-key: ${{ inputs.aws-secret-access-key }}

--- a/codedeploy/s3copy/action.yml
+++ b/codedeploy/s3copy/action.yml
@@ -27,7 +27,7 @@ runs:
   steps:
     # https://github.com/marketplace/actions/configure-aws-credentials-action-for-github-actions
     - name: Configure AWS Credentials
-      uses: aws-actions/configure-aws-credentials@v5
+      uses: aws-actions/configure-aws-credentials@v6
       with:
         aws-access-key-id: ${{ inputs.aws-access-key-id }}
         aws-secret-access-key: ${{ inputs.aws-secret-access-key }}

--- a/docker/action.yml
+++ b/docker/action.yml
@@ -43,7 +43,6 @@ runs:
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v4
       with:
-        install: true
         # Intentionally using latest buildkit for newest features and fixes
         driver-opts: image=moby/buildkit:latest,network=host
 

--- a/docker/action.yml
+++ b/docker/action.yml
@@ -34,14 +34,14 @@ runs:
 
     # https://github.com/marketplace/actions/docker-login
     - name: Log in to Docker Hub
-      uses: docker/login-action@v3
+      uses: docker/login-action@v4
       with:
         username: ${{ inputs.username }}
         password: ${{ inputs.password }}
 
     # https://github.com/marketplace/actions/docker-setup-buildx
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
+      uses: docker/setup-buildx-action@v4
       with:
         install: true
         # Intentionally using latest buildkit for newest features and fixes
@@ -50,14 +50,14 @@ runs:
     # https://github.com/marketplace/actions/docker-metadata-action
     - name: Extract Metadata (tags, labels) for Docker
       id: meta
-      uses: docker/metadata-action@v5
+      uses: docker/metadata-action@v6
       with:
         images: ${{ inputs.username }}/${{ env.REPO_NAME }}
 
     # https://github.com/marketplace/actions/build-and-push-docker-images
     - name: Build and Push Docker Images
       id: push
-      uses: docker/build-push-action@v6
+      uses: docker/build-push-action@v7
       with:
         context: .
         file: ./Dockerfile
@@ -68,7 +68,7 @@ runs:
 
     # https://github.com/marketplace/actions/attest-build-provenance
     - name: Generate Artifact Attestation
-      uses: actions/attest-build-provenance@v3
+      uses: actions/attest-build-provenance@v4
       with:
         subject-name: docker.io/${{ inputs.username }}/${{ env.REPO_NAME }}
         subject-digest: ${{ steps.push.outputs.digest }}

--- a/linters/phpstan/action.yml
+++ b/linters/phpstan/action.yml
@@ -58,7 +58,7 @@ runs:
 
     # https://github.com/marketplace/actions/webfactory-ssh-agent
     - name: Setup SSH Agent
-      uses: webfactory/ssh-agent@v0.9.1
+      uses: webfactory/ssh-agent@v0.10.0
       if: ${{ inputs.ssh-key != ''}}
       with:
         ssh-private-key: ${{ inputs.ssh-key }}

--- a/linters/trivy/action.yml
+++ b/linters/trivy/action.yml
@@ -88,7 +88,7 @@ runs:
 
     # https://github.com/marketplace/actions/aqua-security-trivy
     - name: Run Trivy
-      uses: aquasecurity/trivy-action@0.35.0
+      uses: aquasecurity/trivy-action@v0.36.0
       if: ${{ steps.check.outputs.continue == 'true' }}
       with:
         scan-type: 'fs'

--- a/setup/action.yml
+++ b/setup/action.yml
@@ -542,14 +542,14 @@ runs:
 
     # https://github.com/marketplace/actions/webfactory-ssh-agent
     - name: SSH Agent
-      uses: webfactory/ssh-agent@v0.9.1
+      uses: webfactory/ssh-agent@v0.10.0
       if: ${{ inputs.ssh-key != ''}}
       with:
         ssh-private-key: ${{ inputs.ssh-key }}
 
     # https://github.com/marketplace/actions/configure-aws-credentials-action-for-github-actions
     - name: Configure AWS Credentials
-      uses: aws-actions/configure-aws-credentials@v5
+      uses: aws-actions/configure-aws-credentials@v6
       if: ${{ inputs.aws-access-key-id != '' }}
       with:
         aws-region: ${{ inputs.aws-region }}


### PR DESCRIPTION
## Automated external action bumps

Bumps external GitHub Action references to their latest upstream major/release.
Generated by `bump-actions/bump-actions.sh` (issue #212). Review the linked
release notes for breaking changes before merging.

| Action | From | To |
| --- | --- | --- |
| actions/attest-build-provenance | v3 | v4 |
| aquasecurity/trivy-action | 0.35.0 | v0.36.0 |
| aws-actions/configure-aws-credentials | v5 | v6 |
| docker/build-push-action | v6 | v7 |
| docker/login-action | v3 | v4 |
| docker/metadata-action | v5 | v6 |
| docker/setup-buildx-action | v3 | v4 |
| webfactory/ssh-agent | v0.9.1 | v0.10.0 |

### Upstream release notes

#### actions/attest-build-provenance v4

_Release notes not available; see https://github.com/actions/attest-build-provenance/releases_

#### aquasecurity/trivy-action v0.36.0

## What's Changed
* chore(ci): update bump-trivy workflow by @DmitriyLewen in https://github.com/aquasecurity/trivy-action/pull/546
* ci: use action.yaml as single source of truth for Trivy version by @nikpivkin in https://github.com/aquasecurity/trivy-action/pull/552
* ci: replace peter-evans/create-pull-request with gh CLI by @nikpivkin in https://github.com/aquasecurity/trivy-action/pull/550
* test: use pinned digests for trivy-db, trivy-java-db and trivy-checks by @nikpivkin in https://github.com/aquasecurity/trivy-action/pull/555
* ci: add dependabot config by @nikpivkin in https://github.com/aquasecurity/trivy-action/pull/556
* chore: add zizmor config by @nikpivkin in https://github.com/aquasecurity/trivy-action/pull/557
* chore(deps): bump the actions group with 5 updates by @dependabot[bot] in https://github.com/aquasecurity/trivy-action/pull/558
* fix: use portable shebang in entrypoint.sh by @Hayao0819 in https://github.com/aquasecurity/trivy-action/pull/545
* Fix typo in GOOGLE_APPLICATION_CREDENTIALS env var name by @patrik-csak in https://github.com/aquasecurity/trivy-action/pull/547
* Upgrade Trivy action version from 0.33.1 to 0.35.0 fixes #549 by @Aditya09-cse in https://github.com/aquasecurity/trivy-action/pull/548
* chore: use GitHub Actions as git commit author in bump-trivy workflow by @nikpivkin in https://github.com/aquasecurity/trivy-action/pull/561
* chore(deps): Update trivy to v0.70.0 by @Argon-DevOps-Mgt in https://github.com/aquasecurity/trivy-action/pull/559
* chore: update action version to v0.36.0 in examples by @nikpivkin in https://github.com/aquasecurity/trivy-action/pull/563

## New Contributors
* @dependabot[bot] made their first contribution in https://github.com/aquasecurity/trivy-action/pull/558
* @Hayao0819 made their first contribution in https://github.com/aquasecurity/trivy-action/pull/545
* @patrik-csak made their first contribution in https://github.com/aquasecurity/trivy-action/pull/547
* @Aditya09-cse made their first contribution in https://github.com/aquasecurity/trivy-action/pull/548
* @Argon-DevOps-Mgt made their first contribution in https://github.com/aquasecurity/trivy-action/pull/559

**Full Changelog**: https://github.com/aquasecurity/trivy-action/compare/v0.35.0...v0.36.0

#### aws-actions/configure-aws-credentials v6

_Release notes not available; see https://github.com/aws-actions/configure-aws-credentials/releases_

#### docker/build-push-action v7

_Release notes not available; see https://github.com/docker/build-push-action/releases_

#### docker/login-action v4

_Release notes not available; see https://github.com/docker/login-action/releases_

#### docker/metadata-action v6

_Release notes not available; see https://github.com/docker/metadata-action/releases_

#### docker/setup-buildx-action v4

_Release notes not available; see https://github.com/docker/setup-buildx-action/releases_

#### webfactory/ssh-agent v0.10.0

This release upgrades from node 20 to node 24, preparing for Node 20's upcoming EOL and getting rid of the related warning message in GitHub.

## What's Changed
* use node24 by @jimmymcpeter in https://github.com/webfactory/ssh-agent/pull/243

## New Contributors
* @jimmymcpeter made their first contribution in https://github.com/webfactory/ssh-agent/pull/243

**Full Changelog**: https://github.com/webfactory/ssh-agent/compare/v0.9.1...v0.10.0
