### PR TITLE
Fix tag-build git fetch by using authenticated HTTPS URL

### DIFF
--- a/variables/variables.sh
+++ b/variables/variables.sh
@@ -117,7 +117,12 @@ function main()
   if [[ "${GITHUB_REF:-}" == refs/tags/* ]]; then
     TAG="${GITHUB_REF/refs\/tags\//}"
     SOURCE_REF="${TAG}"
-    git fetch --depth=1 origin +refs/tags/*:refs/tags/*
+    # Fetch over an authenticated HTTPS URL rather than `origin`. The checkout
+    # step runs with persist-credentials:false, which strips the deploy key's
+    # core.sshCommand while leaving origin pointed at git@github.com, so a plain
+    # `git fetch origin` here fails with "Permission denied (publickey)" on tag
+    # builds. GITHUB_TOKEN is exported by the action step for this purpose.
+    git fetch --depth=1 "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" +refs/tags/*:refs/tags/*
     COMMIT_MESSAGE="$(git tag -l --format='%(contents:subject)' "${TAG}")"
   elif [ -n "${GITHUB_HEAD_REF:-}" ]; then
     SOURCE_REF="${GITHUB_HEAD_REF}"


### PR DESCRIPTION
## Summary

Tag builds were failing in the `variables` action when fetching tag refs. The
checkout step runs with `persist-credentials: false`, which strips the deploy
key's `core.sshCommand` while leaving `origin` pointed at `git@github.com`. As a
result, the subsequent `git fetch origin` over SSH failed with
`Permission denied (publickey)` on tag builds.

This change fetches over an authenticated HTTPS URL built from `GITHUB_TOKEN`
(the GitHub-recommended `x-access-token` form) instead of relying on the `origin`
SSH remote, so tag ref fetches succeed regardless of the persisted SSH creds.

**Key changes:**

- Replace `git fetch --depth=1 origin +refs/tags/*:refs/tags/*` with a fetch
  against `https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git`
  on the tag-build path in `variables/variables.sh`.
- Add an explanatory comment documenting why the authenticated HTTPS URL is
  required (persist-credentials:false strips the SSH command).

## Types of changes

- [x] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [ ] Build or security update (updates dependencies, libraries, or security patches)
- [ ] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

- [ ] Unit tests added to validate my fix/feature
- [ ] I have manually tested my change
- [x] I did not add automation test. Why ?: This path authenticates against GitHub with a real token and tag refs, which cannot be reproduced in the unit/contract test harness.
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] \`readme.md\` includes sections on introduction, installation, usage, and contributing
- [ ] \`docs/architecture.md\` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified