### PR TITLE
Bump Node to 26.3.0, ignore generated workflow JS, bump slack deps

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -4,7 +4,7 @@
     "es2021": true
   },
   // ghb:excluded-dirs:start - managed by github-build from config/languages.yaml; do not edit by hand
-  "ignorePatterns": ["**/.build/**", "**/.bundle/**", "**/.git/**", "**/.gradle/**", "**/.hg/**", "**/.m2/**", "**/.npm/**", "**/.pnpm/**", "**/.pytest_cache/**", "**/.svn/**", "**/.venv/**", "**/.yarn/**", "**/__pycache__/**", "**/build/**", "**/Carthage/**", "**/coverage/**", "**/DerivedData/**", "**/dist/**", "**/env/**", "**/Libraries/**", "**/node_modules/**", "**/Pods/**", "**/target/**", "**/vendor/**", "**/venv/**"],
+  "ignorePatterns": ["**/.build/**", "**/.bundle/**", "**/.git/**", "**/.gradle/**", "**/.hg/**", "**/.m2/**", "**/.npm/**", "**/.pnpm/**", "**/.pytest_cache/**", "**/.svn/**", "**/.venv/**", "**/.yarn/**", "**/__pycache__/**", "**/build/**", "**/Carthage/**", "**/coverage/**", "**/DerivedData/**", "**/dist/**", "**/env/**", "**/Libraries/**", "**/node_modules/**", "**/Pods/**", "**/target/**", "**/vendor/**", "**/venv/**", "**/*.workflow.js"],
   // ghb:excluded-dirs:end
   "extends": ["eslint:recommended"],
   "parserOptions": {

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ permissions:
   pull-requests: read
 env:
   NODE-CACHE: npm
-  NODE-VERSION: 26.2.0
+  NODE-VERSION: 26.3.0
 concurrency:
   group: build-${{github.ref}}
   cancel-in-progress: true

--- a/slack/package-lock.json
+++ b/slack/package-lock.json
@@ -2201,9 +2201,9 @@
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.365",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.365.tgz",
-      "integrity": "sha512-xfip4u1QF1s+URFqpA6N+OeFpDGpN7VJz1f3MO3bVL0QYBjpGiZ5/Of7kugvM+o8TTqmanUlviHN3c8M9vYWCw==",
+      "version": "1.5.366",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.366.tgz",
+      "integrity": "sha512-OlRuhb688YTCzzU3gXPLn6nGyd+F+53INE1qaKKlu6kETErE8FYsyDh0XqXEU+uBRn0MpCzz2vfNwORhkap8qg==",
       "dev": true,
       "license": "ISC"
     },


### PR DESCRIPTION
## Summary

Routine maintenance update bumping the build toolchain and dependencies. The
ESLint config now ignores generated `*.workflow.js` files, the build workflow
moves to Node 26.3.0, and the slack package lock picks up a patch bump for a
transitive dev dependency.

**Key changes:**

- Add `**/*.workflow.js` to the `.eslintrc.json` ignore patterns (managed by github-build) so generated workflow JS is not linted
- Bump `NODE-VERSION` to `26.3.0` in `.github/workflows/build.yml`
- Bump `electron-to-chromium` from `1.5.365` to `1.5.366` in `slack/package-lock.json`

## Types of changes

- [ ] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [x] Build or security update (updates dependencies, libraries, or security patches)
- [ ] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

- [ ] Unit tests added to validate my fix/feature
- [ ] I have manually tested my change
- [x] I did not add automation test. Why ?: Dependency and config version bumps with no logic changes
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] `readme.md` includes sections on introduction, installation, usage, and contributing
- [ ] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified