### PR TITLE
Add Trivy scanner config and bump electron-to-chromium lockfile entry

### DIFF
--- a/slack/package-lock.json
+++ b/slack/package-lock.json
@@ -2201,9 +2201,9 @@
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.366",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.366.tgz",
-      "integrity": "sha512-OlRuhb688YTCzzU3gXPLn6nGyd+F+53INE1qaKKlu6kETErE8FYsyDh0XqXEU+uBRn0MpCzz2vfNwORhkap8qg==",
+      "version": "1.5.367",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.367.tgz",
+      "integrity": "sha512-4Mk/mrynCNQ+atY40D3UpmhLWB6AHMbYMlIrPhHcMF6x0L7O0b052FCAsxw1LlaR++UFuNg3D/A6XCuGDa0guQ==",
       "dev": true,
       "license": "ISC"
     },

--- a/trivy.yaml
+++ b/trivy.yaml
@@ -1,0 +1,39 @@
+# Trivy scanner configuration
+# https://trivy.dev/latest/docs/references/configuration/config-file/
+#
+# scan.skip-dirs lists directories Trivy ignores. The block between the
+# ghb:excluded-dirs sentinels is managed by github-build from
+# config/languages.yaml -- do not edit it by hand. Add your own project-specific
+# directories OUTSIDE the sentinels (e.g. below the end marker); they are
+# preserved across rebuilds.
+#
+# Vulnerability/CVE IDs to ignore go in .trivyignore, not here.
+scan:
+  skip-dirs:
+    # ghb:excluded-dirs:start - managed by github-build from config/languages.yaml; do not edit by hand
+    - "**/.build"
+    - "**/.bundle"
+    - "**/.git"
+    - "**/.gradle"
+    - "**/.hg"
+    - "**/.m2"
+    - "**/.npm"
+    - "**/.pnpm"
+    - "**/.pytest_cache"
+    - "**/.svn"
+    - "**/.venv"
+    - "**/.yarn"
+    - "**/__pycache__"
+    - "**/build"
+    - "**/Carthage"
+    - "**/coverage"
+    - "**/DerivedData"
+    - "**/dist"
+    - "**/env"
+    - "**/Libraries"
+    - "**/node_modules"
+    - "**/Pods"
+    - "**/target"
+    - "**/vendor"
+    - "**/venv"
+    # ghb:excluded-dirs:end


### PR DESCRIPTION
## Summary

Routine maintenance update adding a Trivy scanner configuration file and refreshing a transitive dev-dependency lockfile entry. The new \`trivy.yaml\` standardizes the directory skip-list for IaC/vulnerability scanning, with the excluded-dirs block managed by github-build via \`config/languages.yaml\` (sentinel-delimited so project-specific entries are preserved across rebuilds).

**Key changes:**

- Add \`trivy.yaml\` with \`scan.skip-dirs\` covering common build/dependency/cache directories, delimited by \`ghb:excluded-dirs\` sentinels for github-build management
- Bump \`electron-to-chromium\` lockfile entry from 1.5.366 to 1.5.367 in \`slack/package-lock.json\` (transitive dev dependency)

## Types of changes

- [ ] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [x] Build or security update (updates dependencies, libraries, or security patches)
- [ ] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

- [ ] Unit tests added to validate my fix/feature
- [ ] I have manually tested my change
- [x] I did not add automation test. Why ?: Configuration and dependency-lockfile changes only; no code behavior changes
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] \`readme.md\` includes sections on introduction, installation, usage, and contributing
- [ ] \`docs/architecture.md\` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified