### PR TITLE
Drop --mono_repo flag from generated build workflow command

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-# github-build --organization Cloud-Officer --mono_repo --skip_license_check --skip_slack
+# github-build --organization Cloud-Officer --skip_license_check --skip_slack
 ---
 name: Build
 'on':


### PR DESCRIPTION
## Summary

Regenerates the build workflow without the `--mono_repo` flag in the `github-build` command header. The repository is no longer treated as a mono-repo by the generator, so the recorded generation command is updated to match.

**Key changes:**

- Remove `--mono_repo` from the `github-build` command comment at the top of `.github/workflows/build.yml`

## Types of changes

- [ ] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [x] Build or security update (updates dependencies, libraries, or security patches)
- [ ] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

- [ ] Unit tests added to validate my fix/feature
- [ ] I have manually tested my change
- [x] I did not add automation test. Why ?: Single-line change to the generated workflow header comment; no testable behavior change
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] `readme.md` includes sections on introduction, installation, usage, and contributing
- [ ] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified