### PR TITLE
#234 #235: Add tag-build path and TRIVY/CFNLINT detection tests for variables.sh

### DIFF
--- a/variables/tests/variables.bats
+++ b/variables/tests/variables.bats
@@ -386,6 +386,13 @@ teardown() {
   [[ "$LINTERS" == *"BANDIT"* ]]
 }
 
+@test "linter detection: CFNLINT detected from .cfnlintrc file" {
+  touch "${TEST_DIR}/.cfnlintrc"
+  LINTERS=""
+  add_linter_if_file "CFNLINT" "${TEST_DIR}/.cfnlintrc"
+  [[ "$LINTERS" == *"CFNLINT"* ]]
+}
+
 @test "linter detection: ESLINT detected from .eslintrc.json file" {
   touch "${TEST_DIR}/.eslintrc.json"
   LINTERS=""
@@ -496,6 +503,36 @@ teardown() {
   LINTERS=""
   add_linter_if_file "YAMLLINT" "${TEST_DIR}/.yamllint.yml"
   [[ "$LINTERS" == *"YAMLLINT"* ]]
+}
+
+# TRIVY is detected by a depth-bounded find over the working tree (not a single
+# config-file check), so these cases cd into a fixture tree and call the
+# extracted detect_trivy predicate directly.
+
+@test "linter detection: TRIVY detected when a Dockerfile is present at the root" {
+  touch "${TEST_DIR}/Dockerfile"
+  cd "${TEST_DIR}"
+  run detect_trivy
+  [ "$status" -eq 0 ]
+}
+
+@test "linter detection: TRIVY detected from a package-lock.json nested at depth 3" {
+  # Proves the find descends into subdirectories (within -maxdepth 3), not just
+  # the root: a/b/package-lock.json is three levels deep.
+  mkdir -p "${TEST_DIR}/a/b"
+  touch "${TEST_DIR}/a/b/package-lock.json"
+  cd "${TEST_DIR}"
+  run detect_trivy
+  [ "$status" -eq 0 ]
+}
+
+@test "linter detection: TRIVY not detected when no IaC or manifest files present" {
+  mkdir -p "${TEST_DIR}/src"
+  touch "${TEST_DIR}/src/main.py"
+  touch "${TEST_DIR}/README.md"
+  cd "${TEST_DIR}"
+  run detect_trivy
+  [ "$status" -eq 1 ]
 }
 
 @test "linter detection: no linters detected when no config files present" {
@@ -666,4 +703,62 @@ teardown() {
   grep -qE "BUILD_NAME=feature_tags-cleanup-.+" "${GITHUB_OUTPUT}"
   # BUILD_NAME must not contain a slash (a slash means the tag path mangled it).
   ! grep -E "^BUILD_NAME=.*/" "${GITHUB_OUTPUT}"
+}
+
+@test "tag ref drives the tag-build path: prod deploy, tag BUILD_NAME, tag-subject COMMIT_MESSAGE" {
+  # Exercise the refs/tags/* branch of main() (the production-deploy gate) end to
+  # end, the path two real bugs escaped on with green CI (#214, #224). The
+  # authenticated `git fetch` to github.com is replaced by a PATH-shimmed git so
+  # the test stays offline; the tag already exists locally, so every other git
+  # subcommand (rev-parse, tag -l) passes through to the real binary.
+  local repo="${TEST_DIR}/repo"
+  mkdir -p "${repo}"
+  (
+    cd "${repo}" || exit 1
+    git init -q
+    git config user.email test@example.com
+    git config user.name test
+    echo x > file.txt
+    git add file.txt
+    git commit -q -m "Initial commit"
+    git tag -a v1.0.0 -m "Release v1.0.0 #prod-deploy"
+  )
+
+  local shim_dir="${TEST_DIR}/bin"
+  local real_git
+  real_git="$(command -v git)"
+  mkdir -p "${shim_dir}"
+  cat > "${shim_dir}/git" <<EOF
+#!/usr/bin/env bash
+# Make the authenticated tag fetch a no-op; pass everything else to real git.
+if [ "\$1" = "fetch" ]; then
+  exit 0
+fi
+exec "${real_git}" "\$@"
+EOF
+  chmod +x "${shim_dir}/git"
+
+  run bash -c "cd '${repo}' && \
+    PATH=\"${shim_dir}:\$PATH\" \
+    GITHUB_REF=refs/tags/v1.0.0 GITHUB_HEAD_REF='' \
+    GITHUB_TOKEN=dummy-token GITHUB_REPOSITORY=owner/repo \
+    GITHUB_RUN_NUMBER=100 \
+    GITHUB_ENV='${GITHUB_ENV}' GITHUB_OUTPUT='${GITHUB_OUTPUT}' \
+    bash '${BATS_TEST_DIRNAME}/../variables.sh'"
+
+  [ "${status}" -eq 0 ]
+
+  # DEPLOY_ON_PROD is gated on (#prod-deploy trigger AND a non-empty TAG); only
+  # the tag path can satisfy both, so this is the real production-deploy gate.
+  grep -q "DEPLOY_ON_PROD=1" "${GITHUB_OUTPUT}"
+  # COMMIT_MESSAGE comes from the annotated tag's subject, not git log.
+  grep -q "COMMIT_MESSAGE=Release v1.0.0 #prod-deploy" "${GITHUB_OUTPUT}"
+  # BUILD_NAME is derived from the bare tag name (no refs/tags/ prefix, no slash).
+  grep -qE "BUILD_NAME=v1.0.0-.+" "${GITHUB_OUTPUT}"
+  ! grep -E "^BUILD_NAME=.*/" "${GITHUB_OUTPUT}"
+  # Unrelated triggers stay off.
+  grep -q "DEPLOY_ON_BETA=0" "${GITHUB_OUTPUT}"
+
+  # Mirrored to GITHUB_ENV as well.
+  grep -q "DEPLOY_ON_PROD=1" "${GITHUB_ENV}"
 }

--- a/variables/variables.sh
+++ b/variables/variables.sh
@@ -84,6 +84,26 @@ function add_linter_if_dir()
   return 0
 }
 
+# TRIVY is enabled when IaC files or package-manager manifests are present
+# anywhere within the first three directory levels of the working tree. Kept as
+# a sourceable predicate (like add_linter_if_*) so the detection can be unit
+# tested without re-implementing the find expression. Returns 0 when at least
+# one matching file exists, 1 otherwise.
+function detect_trivy()
+{
+  find . -maxdepth 3 \( \
+     -name "Dockerfile*" -o -name "*.tf" -o \
+     -name ".cfnlintrc" -o -name ".hadolint.yaml" -o \
+     -name "package.json" -o -name "package-lock.json" -o \
+     -name "yarn.lock" -o -name "pnpm-lock.yaml" -o \
+     -name "go.sum" -o -name "requirements.txt" -o \
+     -name "Pipfile.lock" -o -name "poetry.lock" -o \
+     -name "Gemfile.lock" -o -name "composer.lock" -o \
+     -name "pom.xml" -o -name "build.gradle" -o -name "build.gradle.kts" -o \
+     -name "Cargo.lock" -o -name "Package.resolved" \
+     \) -print -quit 2>/dev/null | grep -q .
+}
+
 # Resolve build identifiers and skip/deploy flags from the environment and the
 # commit message, then export them to GITHUB_ENV / GITHUB_OUTPUT. Wrapped in a
 # function so the test suite can source this file for its helpers without
@@ -192,17 +212,7 @@ function main()
   add_linter_if_file "SHELLCHECK"    ".shellcheckrc"
   add_linter_if_file "SWIFTLINT"     ".swiftlint.yml"
   # TRIVY - enabled when IaC files or package manager files are present
-  if find . -maxdepth 3 \( \
-     -name "Dockerfile*" -o -name "*.tf" -o \
-     -name ".cfnlintrc" -o -name ".hadolint.yaml" -o \
-     -name "package.json" -o -name "package-lock.json" -o \
-     -name "yarn.lock" -o -name "pnpm-lock.yaml" -o \
-     -name "go.sum" -o -name "requirements.txt" -o \
-     -name "Pipfile.lock" -o -name "poetry.lock" -o \
-     -name "Gemfile.lock" -o -name "composer.lock" -o \
-     -name "pom.xml" -o -name "build.gradle" -o -name "build.gradle.kts" -o \
-     -name "Cargo.lock" -o -name "Package.resolved" \
-     \) -print -quit 2>/dev/null | grep -q .; then
+  if detect_trivy; then
     LINTERS="${LINTERS} TRIVY"
   fi
   add_linter_if_file "YAMLLINT"      ".yamllint.yml"


### PR DESCRIPTION
## Summary

Adds the unit-test coverage flagged by the 2026-06-10 deep code review (TEST-008 and TEST-009) for two untested paths in `variables/variables.sh`. The tag-build branch of `main()` (which gates production deploys) and the TRIVY/CFNLINT linter detection had zero coverage — both are silent-failure surfaces where a regression yields green CI.

**Key changes:**

- **#234 (TEST-008):** new bats E2E test that drives the real `main()` as a subprocess through the `refs/tags/*` branch — the production-deploy gate that bugs #214 and #224 escaped on with CI green. A PATH-shimmed `git` no-ops the authenticated tag fetch so the test stays offline; all other git calls pass through. Asserts `DEPLOY_ON_PROD=1`, tag-subject `COMMIT_MESSAGE`, slash-free tag-derived `BUILD_NAME`, and mirroring to `GITHUB_ENV`.
- **#235 (TEST-009):** extracted the 19-pattern TRIVY `find` block into a sourceable `detect_trivy()` predicate (semantics-preserving — same patterns, `-maxdepth 3`, `-print -quit | grep -q .`), then added 3 detection tests (Dockerfile at root, `package-lock.json` nested at depth 3, no-match tree) plus a CFNLINT `.cfnlintrc` detection test.
- No detection semantics or `variables.sh` runtime behavior changed; the `main()` linter chain now calls `detect_trivy` instead of inlining the find.

All 71 bats tests pass (`cd variables && bats tests/`); shellcheck clean on `variables.sh`.

Closes #234
Closes #235

## Types of changes

- [ ] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [x] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [ ] Build or security update (updates dependencies, libraries, or security patches)
- [ ] Code style or documentation update (formatting, renaming, or documentation changes)
- [x] Other (please describe): adds missing unit-test coverage (no production behavior change)

## Checklist

- [x] Unit tests added to validate my fix/feature
- [x] I have manually tested my change
- [ ] I did not add automation test. Why ?:
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] `readme.md` includes sections on introduction, installation, usage, and contributing
- [ ] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified