### PR TITLE
Fix #236 #237: Sanitize all slashes in build identifiers (SOURCE_REF)

### DIFF
--- a/variables/tests/variables.bats
+++ b/variables/tests/variables.bats
@@ -762,3 +762,111 @@ EOF
   # Mirrored to GITHUB_ENV as well.
   grep -q "DEPLOY_ON_PROD=1" "${GITHUB_ENV}"
 }
+
+@test "branch ref with multiple slashes is fully sanitized in BUILD_NAME" {
+  # Regression (#236 / BUG-009): SAFE_BRANCH used single-occurrence ${x/\//_},
+  # so only the first slash was replaced. A branch two or more levels deep
+  # (refs/heads/feature/a/b) left a literal slash in BUILD_NAME/BUILD_VERSION,
+  # which then break the downstream zip/CodeDeploy/S3 steps.
+  local repo="${TEST_DIR}/repo"
+  mkdir -p "${repo}"
+  (
+    cd "${repo}" || exit 1
+    git init -q
+    git config user.email test@example.com
+    git config user.name test
+    echo x > file.txt
+    git add file.txt
+    git commit -q -m "Deep branch build commit"
+  )
+
+  run bash -c "cd '${repo}' && \
+    GITHUB_REF=refs/heads/feature/a/b GITHUB_HEAD_REF='' \
+    GITHUB_SHA=HEAD GITHUB_RUN_NUMBER=100 \
+    GITHUB_ENV='${GITHUB_ENV}' GITHUB_OUTPUT='${GITHUB_OUTPUT}' \
+    bash '${BATS_TEST_DIRNAME}/../variables.sh'"
+
+  [ "${status}" -eq 0 ]
+  # Every slash replaced: feature/a/b -> feature_a_b.
+  grep -qE "BUILD_NAME=feature_a_b-.+" "${GITHUB_OUTPUT}"
+  grep -qE "BUILD_VERSION=feature_a_b-.+" "${GITHUB_OUTPUT}"
+  # Invariant: no slash survives in either identifier.
+  ! grep -E "^BUILD_NAME=.*/" "${GITHUB_OUTPUT}"
+  ! grep -E "^BUILD_VERSION=.*/" "${GITHUB_OUTPUT}"
+}
+
+@test "PR head ref with a slash is sanitized in BUILD_NAME" {
+  # Regression (#237 / BUG-010): the PR-head path set SOURCE_REF straight from
+  # GITHUB_HEAD_REF with no slash sanitization, so a PR opened from a slash-named
+  # branch (the common convention) put a literal slash into BUILD_NAME.
+  local repo="${TEST_DIR}/repo"
+  mkdir -p "${repo}"
+  (
+    cd "${repo}" || exit 1
+    git init -q
+    git config user.email test@example.com
+    git config user.name test
+    echo x > file.txt
+    git add file.txt
+    git commit -q -m "PR build commit"
+  )
+
+  run bash -c "cd '${repo}' && \
+    GITHUB_REF=refs/pull/7/merge GITHUB_HEAD_REF=feature/foo \
+    GITHUB_RUN_NUMBER=100 \
+    GITHUB_ENV='${GITHUB_ENV}' GITHUB_OUTPUT='${GITHUB_OUTPUT}' \
+    bash '${BATS_TEST_DIRNAME}/../variables.sh'"
+
+  [ "${status}" -eq 0 ]
+  grep -qE "BUILD_NAME=feature_foo-.+" "${GITHUB_OUTPUT}"
+  grep -qE "BUILD_VERSION=feature_foo-.+" "${GITHUB_OUTPUT}"
+  ! grep -E "^BUILD_NAME=.*/" "${GITHUB_OUTPUT}"
+  ! grep -E "^BUILD_VERSION=.*/" "${GITHUB_OUTPUT}"
+}
+
+@test "tag ref with a slash is sanitized in BUILD_NAME" {
+  # Regression (#237 / BUG-010): the tag path set SOURCE_REF from the raw tag
+  # name, so a slash-containing tag (e.g. releases/1.0) put a literal slash into
+  # BUILD_NAME. The fetch is stubbed via a PATH-shimmed git (same as the
+  # tag-build-path test); the tag exists locally so tag -l passes through.
+  local repo="${TEST_DIR}/repo"
+  mkdir -p "${repo}"
+  (
+    cd "${repo}" || exit 1
+    git init -q
+    git config user.email test@example.com
+    git config user.name test
+    echo x > file.txt
+    git add file.txt
+    git commit -q -m "Initial commit"
+    git tag -a releases/1.0 -m "Release releases/1.0"
+  )
+
+  local shim_dir="${TEST_DIR}/bin"
+  local real_git
+  real_git="$(command -v git)"
+  mkdir -p "${shim_dir}"
+  cat > "${shim_dir}/git" <<EOF
+#!/usr/bin/env bash
+if [ "\$1" = "fetch" ]; then
+  exit 0
+fi
+exec "${real_git}" "\$@"
+EOF
+  chmod +x "${shim_dir}/git"
+
+  run bash -c "cd '${repo}' && \
+    PATH=\"${shim_dir}:\$PATH\" \
+    GITHUB_REF=refs/tags/releases/1.0 GITHUB_HEAD_REF='' \
+    GITHUB_TOKEN=dummy-token GITHUB_REPOSITORY=owner/repo \
+    GITHUB_RUN_NUMBER=100 \
+    GITHUB_ENV='${GITHUB_ENV}' GITHUB_OUTPUT='${GITHUB_OUTPUT}' \
+    bash '${BATS_TEST_DIRNAME}/../variables.sh'"
+
+  [ "${status}" -eq 0 ]
+  # releases/1.0 -> releases_1.0 in the build identifiers.
+  grep -qE "BUILD_NAME=releases_1.0-.+" "${GITHUB_OUTPUT}"
+  grep -qE "BUILD_VERSION=releases_1.0-.+" "${GITHUB_OUTPUT}"
+  ! grep -E "^BUILD_NAME=.*/" "${GITHUB_OUTPUT}"
+  ! grep -E "^BUILD_VERSION=.*/" "${GITHUB_OUTPUT}"
+}

--- a/variables/variables.sh
+++ b/variables/variables.sh
@@ -123,7 +123,11 @@ function main()
   SHORT_COMMIT="$(git rev-parse --short HEAD)"
   SAFE_BRANCH="${GITHUB_REF:-/refs/heads/}"
   SAFE_BRANCH="${SAFE_BRANCH/refs\/heads\//}"
-  SAFE_BRANCH="${SAFE_BRANCH/\//_}"
+  # Global substitution (//): a branch nested two or more levels deep
+  # (e.g. feature/a/b) contains multiple slashes; replacing only the first left
+  # a literal slash in BUILD_NAME. SOURCE_REF below is sanitized again uniformly,
+  # but keep SAFE_BRANCH self-consistent for any direct use.
+  SAFE_BRANCH="${SAFE_BRANCH//\//_}"
   MODIFIED_GITHUB_RUN_NUMBER=$(( ${GITHUB_RUN_NUMBER:-0} + 15000 ))
   export MODIFIED_GITHUB_RUN_NUMBER
   # Resolve the source ref and the raw commit message; only these differ
@@ -155,6 +159,13 @@ function main()
   # Take only the first line: `git ... | head` would mask a git failure under
   # pipefail (and head closing the pipe trips pipefail too).
   COMMIT_MESSAGE="${COMMIT_MESSAGE%%$'\n'*}"
+
+  # Sanitize the resolved ref once, for all three paths (tag, PR head, branch):
+  # the tag and PR-head paths assign SOURCE_REF from raw refs with no cleanup, so
+  # a slash-named PR branch (feature/foo) or a slash-containing tag (releases/1.0)
+  # would otherwise leak a literal slash into BUILD_NAME/BUILD_VERSION, which are
+  # used downstream as S3 keys and zip/CodeDeploy identifiers.
+  SOURCE_REF="${SOURCE_REF//\//_}"
 
   BUILD_NAME="${SOURCE_REF}-${SHORT_COMMIT}-${TIMESTAMP}-${MODIFIED_GITHUB_RUN_NUMBER}"
   BUILD_VERSION="${SOURCE_REF}-${MODIFIED_GITHUB_RUN_NUMBER}-${TIMESTAMP}"


### PR DESCRIPTION
## Summary

Fixes two related slash-sanitization bugs (BUG-009, BUG-010) in `variables/variables.sh` where `BUILD_NAME`/`BUILD_VERSION` could contain a literal `/`. Those identifiers are exported to `GITHUB_ENV`/`GITHUB_OUTPUT` and used downstream as S3 keys and zip/CodeDeploy identifiers, so a stray slash silently creates nested S3 "directories" or breaks the `zip "${BUILD_NAME}.zip"` step in every consumer pipeline.

**Key changes:**

- **#236 (BUG-009):** `SAFE_BRANCH` used single-occurrence substitution `${SAFE_BRANCH/\//_}`, replacing only the *first* slash — a branch nested 2+ levels deep (`feature/a/b` -> `feature_a/b`) leaked a slash. Changed to global `//` substitution.
- **#237 (BUG-010):** the tag path and PR-head path set `SOURCE_REF` from raw refs with no sanitization, so a slash-named PR branch (`feature/foo`) or slash-containing tag (`releases/1.0`) leaked a slash. Added a single `SOURCE_REF="${SOURCE_REF//\//_}"` right before `BUILD_NAME`/`BUILD_VERSION` derivation, covering tag, PR-head, and branch paths uniformly.
- Added 3 bats regression tests (multi-slash branch, slash PR head, slash tag), each asserting no slash survives in `BUILD_NAME` *or* `BUILD_VERSION`. Confirmed all three **fail before** the fix and **pass after**.

All 74 bats tests pass (`cd variables && bats tests/`); shellcheck clean on `variables.sh`. No other behavior changed.

Fixes #236
Fixes #237

## Types of changes

- [x] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [ ] Build or security update (updates dependencies, libraries, or security patches)
- [ ] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

- [x] Unit tests added to validate my fix/feature
- [x] I have manually tested my change
- [ ] I did not add automation test. Why ?:
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] `readme.md` includes sections on introduction, installation, usage, and contributing
- [ ] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified