### PR TITLE
#238: Single-source the Trivy lock-file list shared by variables.sh and trivy action

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -37,6 +37,9 @@ jobs:
     - name: Validate every action.yml
       shell: bash
       run: python3 tests/action_contracts.py
+    - name: Assert the Trivy lock-file list stays single-sourced
+      shell: bash
+      run: python3 tests/lock_file_contract.py
 
   linters-smoke:
     name: Linter actions (disabled path)

--- a/linters/_lib/lock_files.sh
+++ b/linters/_lib/lock_files.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+
+# Single source of truth for the package-manager lock/manifest files that mark a
+# project Trivy should run a vulnerability scan against (QUAL-010, #238).
+#
+# Sourced by both consumers so the list lives in exactly one place:
+#   - variables/variables.sh  detect_trivy()  -> enables the TRIVY linter
+#       source ".../variables/../linters/_lib/lock_files.sh"
+#   - linters/trivy/action.yml                -> adds the `vuln` scanner
+#       source "${GITHUB_ACTION_PATH}/../_lib/lock_files.sh"
+#
+# Adding or removing an ecosystem here updates both consumers at once; without
+# single-sourcing, a list that drifts silently produces a Trivy job that runs
+# without the vuln scanner (or never runs at all) with no error surfaced.
+# tests/lock_file_contract.py asserts both consumers keep sourcing this list and
+# do not re-introduce a hardcoded copy.
+#
+# Note: Dockerfile* / *.tf / .cfnlintrc / .hadolint.yaml are IaC markers handled
+# separately (they drive TRIVY's misconfig scanner, not vuln), and package.json
+# enables TRIVY in variables.sh as a manifest without a lock file — none of those
+# belong in this lock-file list.
+
+# shellcheck disable=SC2034  # consumed by the scripts that source this file
+TRIVY_LOCK_FILES=(
+  package-lock.json
+  yarn.lock
+  pnpm-lock.yaml
+  go.sum
+  requirements.txt
+  Pipfile.lock
+  poetry.lock
+  Gemfile.lock
+  composer.lock
+  pom.xml
+  build.gradle
+  build.gradle.kts
+  Cargo.lock
+  Package.resolved
+)

--- a/linters/trivy/action.yml
+++ b/linters/trivy/action.yml
@@ -45,6 +45,11 @@ runs:
       run: |
         scanners="secret"
 
+        # Single source of truth for the package-manager lock-file list, shared
+        # with variables.sh detect_trivy() (QUAL-010, #238) so the two can never
+        # drift. Populates the TRIVY_LOCK_FILES array.
+        source "${GITHUB_ACTION_PATH}/../_lib/lock_files.sh"
+
         # Enable misconfig when IaC files are detected
         if echo "${LINTERS}" | grep -qE "CFNLINT|HADOLINT" || \
            find . -maxdepth 3 -name "*.tf" -print -quit 2>/dev/null | grep -q . || \
@@ -60,11 +65,7 @@ runs:
           done < <(grep 'path = ' .gitmodules | sed 's/.*path = //')
         fi
 
-        for lock_file in package-lock.json yarn.lock pnpm-lock.yaml go.sum \
-                         requirements.txt Pipfile.lock poetry.lock \
-                         Gemfile.lock composer.lock \
-                         pom.xml build.gradle build.gradle.kts \
-                         Cargo.lock Package.resolved; do
+        for lock_file in "${TRIVY_LOCK_FILES[@]}"; do
           if find . "${submodule_paths[@]}" -name "${lock_file}" -print -quit 2>/dev/null | grep -q .; then
             scanners="${scanners},vuln"
             break

--- a/tests/lock_file_contract.py
+++ b/tests/lock_file_contract.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""Contract: the Trivy lock-file list lives in exactly one place.
+
+QUAL-010 (#238). The package-manager lock-file list used to be duplicated as
+domain knowledge in two files that had to be kept in sync by hand:
+
+  - variables/variables.sh  detect_trivy()  -> enables the TRIVY linter
+  - linters/trivy/action.yml                -> adds Trivy's `vuln` scanner
+
+They are now single-sourced from linters/_lib/lock_files.sh. This test enforces
+that single-sourcing so the duplication can never silently come back:
+
+  1. linters/_lib/lock_files.sh sources cleanly and defines a non-empty
+     TRIVY_LOCK_FILES array.
+  2. Each consumer sources lock_files.sh and iterates TRIVY_LOCK_FILES.
+  3. No canonical lock-file name is hardcoded in either consumer -- the only
+     place those names may appear is lock_files.sh itself. A list that drifts
+     (a new ecosystem added to one consumer but not the other) is exactly the
+     silent failure this guards against.
+
+Usage: python3 tests/lock_file_contract.py
+Exits non-zero and prints every violation found.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+SHARED_LIST = os.path.join("linters", "_lib", "lock_files.sh")
+CONSUMERS = (
+    os.path.join("variables", "variables.sh"),
+    os.path.join("linters", "trivy", "action.yml"),
+)
+
+
+def load_lock_files() -> list[str]:
+    """Source the shared list in bash and return the TRIVY_LOCK_FILES entries."""
+    result = subprocess.run(
+        ["bash", "-c", f'source "{SHARED_LIST}"; printf "%s\\n" "${{TRIVY_LOCK_FILES[@]}}"'],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(result.stderr.strip() or "failed to source lock_files.sh")
+    return [line for line in result.stdout.splitlines() if line]
+
+
+def main() -> int:
+    errors: list[str] = []
+
+    shared_path = os.path.join(REPO_ROOT, SHARED_LIST)
+    if not os.path.isfile(shared_path):
+        print(f"{SHARED_LIST}: missing shared lock-file list", file=sys.stderr)
+        return 1
+
+    try:
+        lock_files = load_lock_files()
+    except RuntimeError as exc:
+        print(f"{SHARED_LIST}: {exc}", file=sys.stderr)
+        return 1
+
+    if not lock_files:
+        errors.append(f"{SHARED_LIST}: TRIVY_LOCK_FILES is empty")
+
+    for rel in CONSUMERS:
+        with open(os.path.join(REPO_ROOT, rel), encoding="utf-8") as handle:
+            text = handle.read()
+
+        if "lock_files.sh" not in text:
+            errors.append(f"{rel}: does not source linters/_lib/lock_files.sh")
+        if "TRIVY_LOCK_FILES" not in text:
+            errors.append(f"{rel}: does not reference the TRIVY_LOCK_FILES array")
+
+        # The canonical names must exist ONLY in lock_files.sh. Finding one
+        # hardcoded here means the list has been duplicated again.
+        for name in lock_files:
+            if name in text:
+                errors.append(
+                    f"{rel}: hardcodes lock-file name '{name}' -- "
+                    f"it must come from the shared TRIVY_LOCK_FILES array"
+                )
+
+    for line in errors:
+        print(line, file=sys.stderr)
+
+    print(
+        f"Checked {len(CONSUMERS)} consumer(s) against {len(lock_files)} "
+        f"single-sourced lock files, {len(errors)} violation(s)."
+    )
+    return 1 if errors else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/variables/tests/variables.bats
+++ b/variables/tests/variables.bats
@@ -535,6 +535,17 @@ teardown() {
   [ "$status" -eq 1 ]
 }
 
+@test "linter detection: TRIVY detected from a lock file in the shared list (Gemfile.lock)" {
+  # Locks that detect_trivy actually consumes the single-sourced
+  # linters/_lib/lock_files.sh array (QUAL-010 / #238): Gemfile.lock is only
+  # reachable via that list, not via the IaC/manifest names hardcoded in the
+  # find expression. If the source breaks, the array is empty and this fails.
+  touch "${TEST_DIR}/Gemfile.lock"
+  cd "${TEST_DIR}"
+  run detect_trivy
+  [ "$status" -eq 0 ]
+}
+
 @test "linter detection: no linters detected when no config files present" {
   LINTERS=""
   add_linter_if_dir  "ACTIONLINT"    "${TEST_DIR}/.github/workflows" || true

--- a/variables/variables.sh
+++ b/variables/variables.sh
@@ -89,19 +89,33 @@ function add_linter_if_dir()
 # a sourceable predicate (like add_linter_if_*) so the detection can be unit
 # tested without re-implementing the find expression. Returns 0 when at least
 # one matching file exists, 1 otherwise.
+#
+# The package-manager lock-file portion is single-sourced from
+# linters/_lib/lock_files.sh (QUAL-010, #238) so it can never drift from the
+# trivy action's vuln-scanner list. Dockerfile*/*.tf/.cfnlintrc/.hadolint.yaml
+# (IaC markers) and package.json (manifest without a lock file) additionally
+# enable TRIVY here and are intentionally not part of that shared list.
 function detect_trivy()
 {
-  find . -maxdepth 3 \( \
-     -name "Dockerfile*" -o -name "*.tf" -o \
-     -name ".cfnlintrc" -o -name ".hadolint.yaml" -o \
-     -name "package.json" -o -name "package-lock.json" -o \
-     -name "yarn.lock" -o -name "pnpm-lock.yaml" -o \
-     -name "go.sum" -o -name "requirements.txt" -o \
-     -name "Pipfile.lock" -o -name "poetry.lock" -o \
-     -name "Gemfile.lock" -o -name "composer.lock" -o \
-     -name "pom.xml" -o -name "build.gradle" -o -name "build.gradle.kts" -o \
-     -name "Cargo.lock" -o -name "Package.resolved" \
-     \) -print -quit 2>/dev/null | grep -q .
+  # Resolve the shared list relative to this script so it works both when run as
+  # the action (variables.sh is on PATH, BASH_SOURCE is absolute) and when the
+  # bats suite sources this file from variables/tests/.
+  local lib_dir
+  lib_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/../linters/_lib"
+  # shellcheck source=/dev/null
+  source "${lib_dir}/lock_files.sh"
+
+  local find_args=(
+    -name "Dockerfile*" -o -name "*.tf" -o
+    -name ".cfnlintrc" -o -name ".hadolint.yaml" -o
+    -name "package.json"
+  )
+  local lock_file
+  for lock_file in "${TRIVY_LOCK_FILES[@]}"; do
+    find_args+=( -o -name "${lock_file}" )
+  done
+
+  find . -maxdepth 3 '(' "${find_args[@]}" ')' -print -quit 2>/dev/null | grep -q .
 }
 
 # Resolve build identifiers and skip/deploy flags from the environment and the


### PR DESCRIPTION
## Summary

QUAL-010: the package-manager lock-file list was duplicated as domain knowledge in two files that had to be kept in sync by hand — `variables/variables.sh` `detect_trivy()` (which enables the TRIVY linter) and `linters/trivy/action.yml` (which adds Trivy's `vuln` scanner). Nothing enforced the sync, so a new ecosystem (`uv.lock`, `bun.lock`, …) added to one and not the other would silently produce a Trivy job that runs without the vuln scanner, with no error surfaced. This single-sources the list into one shared file consumed by both.

**Key changes:**

- New `linters/_lib/lock_files.sh` — the single source of truth, defining the canonical `TRIVY_LOCK_FILES` array (14 lock files).
- `variables/variables.sh` `detect_trivy()` now sources the shared list (path resolved via `BASH_SOURCE`, so it works both when run as the action and when the bats suite sources the script). The IaC markers (`Dockerfile*`/`*.tf`/`.cfnlintrc`/`.hadolint.yaml`) and `package.json` stay local and are documented as intentionally not part of the shared lock-file list.
- `linters/trivy/action.yml` vuln loop sources `${GITHUB_ACTION_PATH}/../_lib/lock_files.sh` and iterates the array, mirroring the existing `check_enabled.sh` precedent.
- New `tests/lock_file_contract.py` locks the single-sourcing: both consumers must source the list and may not hardcode any canonical lock-file name. Wired into `smoke.yml` alongside `action_contracts.py`.
- New bats test: `Gemfile.lock` (reachable only via the shared array) triggers detection, proving `variables.sh` actually consumes the list.

No detected ecosystems changed — this is a refactor that makes the existing two lists one.

Verification: bats **75/75** pass (`cd variables && bats tests/`); shellcheck clean on `variables.sh` and `lock_files.sh`; `action_contracts.py` reports 28 files / 0 violations (trivy YAML still valid); the contract test passes on the synced state and was demonstrated to **fail on drift** (hardcoding a lock-file name back into a consumer) then revert.

Closes #238

## Types of changes

- [ ] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [x] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [ ] Build or security update (updates dependencies, libraries, or security patches)
- [ ] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

- [x] Unit tests added to validate my fix/feature
- [x] I have manually tested my change
- [ ] I did not add automation test. Why ?:
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] `readme.md` includes sections on introduction, installation, usage, and contributing
- [ ] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified