### PR TITLE
#239: Run semgrep and trivy on push too (regenerated from github-build)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -133,7 +133,7 @@ jobs:
     runs-on: ubuntu-latest
     needs:
     - variables
-    if: "${{needs.variables.outputs.SKIP_LINTERS != '1' && github.event_name == 'pull_request'}}"
+    if: "${{needs.variables.outputs.SKIP_LINTERS != '1'}}"
     timeout-minutes: 30
     steps:
     - name: Semgrep
@@ -162,7 +162,7 @@ jobs:
     runs-on: ubuntu-latest
     needs:
     - variables
-    if: "${{needs.variables.outputs.SKIP_LINTERS != '1' && github.event_name == 'pull_request'}}"
+    if: "${{needs.variables.outputs.SKIP_LINTERS != '1'}}"
     timeout-minutes: 30
     steps:
     - name: Trivy


### PR DESCRIPTION
## Summary

Regenerated `.github/workflows/build.yml` from the github-build generator fix (Cloud-Officer/github-build#450) for CI-010. Rather than blindly adding a `pull_request` guard to bandit, each linter's capability was audited: linters that report through reviewdog's `github-pr-review` reporter genuinely need a PR; linters that fail the job by exit code are meaningful on pushes too (master, tags, dependabot) and should run there.

**Key changes:**

- `build.yml`: the **semgrep** and **trivy** jobs lose the `&& github.event_name == 'pull_request'` clause — both are exit-code security/vuln scanners (`semgrep ... --error`, trivy `exit-code: 1`) with no reviewdog/PR dependency, so they now run on push too. This is exactly the generator's output for the github-build config change.
- **bandit** was already unguarded (the linter the issue flagged) — correct under the capability rule, so no change there.
- The 6 reviewdog linters enabled in this repo (actionlint, eslint, flake8, markdownlint, shellcheck, yamllint) keep the `pull_request` guard.

The root-cause/source-of-truth change lives in github-build (`config/linters.yaml` + a new rspec spec locking the split); this PR is the regenerated output, so there is no drift. Validated: `build.yml` parses, actionlint clean, every enabled linter's guard matches its capability.

Closes #239