### PR TITLE
Bump external action references

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -24,7 +24,7 @@ jobs:
     timeout-minutes: 10
     steps:
     - name: Checkout
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
       with:
         persist-credentials: false
     - name: Set up Python
@@ -47,7 +47,7 @@ jobs:
     timeout-minutes: 10
     steps:
     - name: Checkout
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
       with:
         persist-credentials: false
     # Each linter is invoked with an empty `linters` list so the shared
@@ -190,7 +190,7 @@ jobs:
     timeout-minutes: 10
     steps:
     - name: Checkout
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
       with:
         persist-credentials: false
     - name: Run variables action

--- a/aws/action.yml
+++ b/aws/action.yml
@@ -27,7 +27,7 @@ runs:
   steps:
     # https://github.com/marketplace/actions/checkout
     - name: Checkout
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
       with:
         token: ${{ inputs.github-token }}
         ssh-key: ${{ inputs.ssh-key }}

--- a/codedeploy/checkout/action.yml
+++ b/codedeploy/checkout/action.yml
@@ -15,7 +15,7 @@ runs:
   steps:
     # https://github.com/marketplace/actions/checkout
     - name: Checkout
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
       with:
         token: ${{ inputs.github-token }}
         ssh-key: ${{ inputs.ssh-key }}

--- a/docker/action.yml
+++ b/docker/action.yml
@@ -19,7 +19,7 @@ runs:
   steps:
     # https://github.com/marketplace/actions/checkout
     - name: Checkout
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
       with:
         token: ${{ inputs.github-token }}
         persist-credentials: false

--- a/linters/actionlint/action.yml
+++ b/linters/actionlint/action.yml
@@ -26,7 +26,7 @@ runs:
 
     # https://github.com/marketplace/actions/checkout
     - name: Checkout
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
       if: ${{ steps.check.outputs.continue == 'true' }}
       with:
         token: ${{ inputs.github-token }}

--- a/linters/bandit/action.yml
+++ b/linters/bandit/action.yml
@@ -26,7 +26,7 @@ runs:
 
     # https://github.com/marketplace/actions/checkout
     - name: Checkout
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
       if: ${{ steps.check.outputs.continue == 'true' }}
       with:
         token: ${{ inputs.github-token }}

--- a/linters/cfnlint/action.yml
+++ b/linters/cfnlint/action.yml
@@ -27,7 +27,7 @@ runs:
 
     # https://github.com/marketplace/actions/checkout
     - name: Checkout
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
       if: ${{ steps.check.outputs.continue == 'true' }}
       with:
         token: ${{ inputs.github-token }}

--- a/linters/eslint/action.yml
+++ b/linters/eslint/action.yml
@@ -30,7 +30,7 @@ runs:
 
     # https://github.com/marketplace/actions/checkout
     - name: Checkout
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
       if: ${{ steps.check.outputs.continue == 'true' }}
       with:
         token: ${{ inputs.github-token }}

--- a/linters/flake8/action.yml
+++ b/linters/flake8/action.yml
@@ -27,7 +27,7 @@ runs:
 
     # https://github.com/marketplace/actions/checkout
     - name: Checkout
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
       if: ${{ steps.check.outputs.continue == 'true' }}
       with:
         token: ${{ inputs.github-token }}

--- a/linters/golangci/action.yml
+++ b/linters/golangci/action.yml
@@ -27,7 +27,7 @@ runs:
 
     # https://github.com/marketplace/actions/checkout
     - name: Checkout
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
       if: ${{ steps.check.outputs.continue == 'true' }}
       with:
         token: ${{ inputs.github-token }}

--- a/linters/hadolint/action.yml
+++ b/linters/hadolint/action.yml
@@ -27,7 +27,7 @@ runs:
 
     # https://github.com/marketplace/actions/checkout
     - name: Checkout
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
       if: ${{ steps.check.outputs.continue == 'true' }}
       with:
         token: ${{ inputs.github-token }}

--- a/linters/ktlint/action.yml
+++ b/linters/ktlint/action.yml
@@ -27,7 +27,7 @@ runs:
 
     # https://github.com/marketplace/actions/checkout
     - name: Checkout
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
       if: ${{ steps.check.outputs.continue == 'true' }}
       with:
         token: ${{ inputs.github-token }}

--- a/linters/markdownlint/action.yml
+++ b/linters/markdownlint/action.yml
@@ -27,7 +27,7 @@ runs:
 
     # https://github.com/marketplace/actions/checkout
     - name: Checkout
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
       if: ${{ steps.check.outputs.continue == 'true' }}
       with:
         token: ${{ inputs.github-token }}

--- a/linters/phpcs/action.yml
+++ b/linters/phpcs/action.yml
@@ -47,7 +47,7 @@ runs:
 
     # https://github.com/marketplace/actions/checkout
     - name: Checkout
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
       if: ${{ steps.check.outputs.continue == 'true' }}
       with:
         token: ${{ inputs.github-token }}

--- a/linters/phpstan/action.yml
+++ b/linters/phpstan/action.yml
@@ -47,7 +47,7 @@ runs:
 
     # https://github.com/marketplace/actions/checkout
     - name: Checkout
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
       if: ${{ steps.check.outputs.continue == 'true' }}
       with:
         token: ${{ inputs.github-token }}

--- a/linters/pmd/action.yml
+++ b/linters/pmd/action.yml
@@ -27,7 +27,7 @@ runs:
 
     # https://github.com/marketplace/actions/checkout
     - name: Checkout
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
       if: ${{ steps.check.outputs.continue == 'true' }}
       with:
         token: ${{ inputs.github-token }}

--- a/linters/protolint/action.yml
+++ b/linters/protolint/action.yml
@@ -27,7 +27,7 @@ runs:
 
     # https://github.com/marketplace/actions/checkout
     - name: Checkout
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
       if: ${{ steps.check.outputs.continue == 'true' }}
       with:
         token: ${{ inputs.github-token }}

--- a/linters/rubocop/action.yml
+++ b/linters/rubocop/action.yml
@@ -31,7 +31,7 @@ runs:
 
     # https://github.com/marketplace/actions/checkout
     - name: Checkout
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
       if: ${{ steps.check.outputs.continue == 'true' }}
       with:
         token: ${{ inputs.github-token }}

--- a/linters/semgrep/action.yml
+++ b/linters/semgrep/action.yml
@@ -26,7 +26,7 @@ runs:
 
     # https://github.com/marketplace/actions/checkout
     - name: Checkout
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
       if: ${{ steps.check.outputs.continue == 'true' }}
       with:
         token: ${{ inputs.github-token }}

--- a/linters/shellcheck/action.yml
+++ b/linters/shellcheck/action.yml
@@ -27,7 +27,7 @@ runs:
 
     # https://github.com/marketplace/actions/checkout
     - name: Checkout
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
       if: ${{ steps.check.outputs.continue == 'true' }}
       with:
         token: ${{ inputs.github-token }}

--- a/linters/swiftlint/action.yml
+++ b/linters/swiftlint/action.yml
@@ -27,7 +27,7 @@ runs:
 
     # https://github.com/marketplace/actions/checkout
     - name: Checkout
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
       if: ${{ steps.check.outputs.continue == 'true' }}
       with:
         token: ${{ inputs.github-token }}

--- a/linters/trivy/action.yml
+++ b/linters/trivy/action.yml
@@ -27,7 +27,7 @@ runs:
 
     # https://github.com/marketplace/actions/checkout
     - name: Checkout
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
       if: ${{ steps.check.outputs.continue == 'true' }}
       with:
         token: ${{ inputs.github-token }}

--- a/linters/yamllint/action.yml
+++ b/linters/yamllint/action.yml
@@ -27,7 +27,7 @@ runs:
 
     # https://github.com/marketplace/actions/checkout
     - name: Checkout
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
       if: ${{ steps.check.outputs.continue == 'true' }}
       with:
         token: ${{ inputs.github-token }}

--- a/setup/action.yml
+++ b/setup/action.yml
@@ -490,7 +490,7 @@ runs:
   steps:
     # https://github.com/marketplace/actions/checkout
     - name: Checkout
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
       with:
         token: ${{ inputs.github-token }}
         fetch-depth: ${{ inputs.fetch-depth }}

--- a/soup/action.yml
+++ b/soup/action.yml
@@ -24,7 +24,7 @@ runs:
   steps:
     # https://github.com/marketplace/actions/checkout
     - name: Checkout
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
       if: ${{ inputs.skip-checkout == 'false' }}
       with:
         ssh-key: ${{ inputs.ssh-key }}

--- a/variables/action.yml
+++ b/variables/action.yml
@@ -63,7 +63,7 @@ runs:
   steps:
     # https://github.com/marketplace/actions/checkout
     - name: Checkout
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
       with:
         token: ${{ inputs.github-token }}
         ssh-key: ${{ inputs.ssh-key }}


### PR DESCRIPTION
## Automated external action bumps

Bumps external GitHub Action references to their latest upstream major/release.
Generated by `bump-actions/bump-actions.sh` (issue #212). Review the linked
release notes for breaking changes before merging.

| Action | From | To |
| --- | --- | --- |
| actions/checkout | v6 | v7 |

### Upstream release notes

#### actions/checkout v7

_Release notes not available; see https://github.com/actions/checkout/releases_
