### PR TITLE
Bump external action references

### DIFF
--- a/linters/phpstan/action.yml
+++ b/linters/phpstan/action.yml
@@ -95,7 +95,7 @@ runs:
         [ -n "$dir" ] || { echo "::error::composer config cache-files-dir returned empty"; exit 1; }
         echo "dir=$dir" >> "${GITHUB_OUTPUT}"
     - name: Cache - Composer
-      uses: actions/cache@v5
+      uses: actions/cache@v6
       if: ${{ steps.check.outputs.continue == 'true' }}
       with:
         path: ${{ steps.composer-cache.outputs.dir }}

--- a/setup/action.yml
+++ b/setup/action.yml
@@ -600,7 +600,7 @@ runs:
 
     # https://github.com/marketplace/actions/cache
     - name: Cache - Go
-      uses: actions/cache@v5
+      uses: actions/cache@v6
       if: ${{ inputs.go-version != 'none' || steps.detect-versions.outputs.go-file }}
       with:
         path: |
@@ -637,7 +637,7 @@ runs:
 
     # https://github.com/marketplace/actions/cache
     - name: Cache - Gradle
-      uses: actions/cache@v5
+      uses: actions/cache@v6
       if: ${{ inputs.java-version != 'none' || steps.detect-versions.outputs.java-file }}
       with:
         path: |
@@ -648,7 +648,7 @@ runs:
 
     # https://github.com/marketplace/actions/cache
     - name: Cache - Maven
-      uses: actions/cache@v5
+      uses: actions/cache@v6
       if: ${{ inputs.java-version != 'none' || steps.detect-versions.outputs.java-file }}
       with:
         path: ~/.m2/repository
@@ -695,7 +695,7 @@ runs:
         [ -n "$dir" ] || { echo "::error::composer config cache-files-dir returned empty"; exit 1; }
         echo "dir=$dir" >> "${GITHUB_OUTPUT}"
     - name: Cache - Composer
-      uses: actions/cache@v5
+      uses: actions/cache@v6
       if: ${{ inputs.php-version != 'none' || steps.detect-versions.outputs.php-file }}
       with:
         path: ${{ steps.composer-cache.outputs.dir }}
@@ -729,7 +729,7 @@ runs:
         [ -n "$dir" ] || { echo "::error::pip cache dir returned empty"; exit 1; }
         echo "dir=$dir" >> "${GITHUB_OUTPUT}"
     - name: Cache - PIP
-      uses: actions/cache@v5
+      uses: actions/cache@v6
       if: ${{ inputs.python-version != 'none' || steps.detect-versions.outputs.python-file }}
       with:
         path: ${{ steps.pip-cache.outputs.dir }}
@@ -774,7 +774,7 @@ runs:
 
     # https://github.com/marketplace/actions/cache
     - name: Cache - Carthage
-      uses: actions/cache@v5
+      uses: actions/cache@v6
       if: ${{ inputs.xcode-version != 'none' && runner.os == 'macOS'}}
       with:
         path: Carthage
@@ -783,7 +783,7 @@ runs:
 
     # https://github.com/marketplace/actions/cache
     - name: Cache - CocoaPods
-      uses: actions/cache@v5
+      uses: actions/cache@v6
       if: ${{ inputs.xcode-version != 'none' && runner.os == 'macOS'}}
       with:
         path: Pods
@@ -792,7 +792,7 @@ runs:
 
     # https://github.com/marketplace/actions/cache
     - name: Cache - SPM
-      uses: actions/cache@v5
+      uses: actions/cache@v6
       if: ${{ inputs.xcode-version != 'none' && runner.os == 'macOS'}}
       with:
         path: .build
@@ -801,7 +801,7 @@ runs:
 
     # https://github.com/marketplace/actions/cache
     - name: Cache - Tuist
-      uses: actions/cache@v5
+      uses: actions/cache@v6
       id: tuist
       if: ${{ inputs.xcode-version != 'none' && runner.os == 'macOS'}}
       with:


### PR DESCRIPTION
## Automated external action bumps

Bumps external GitHub Action references to their latest upstream major/release.
Generated by `bump-actions/bump-actions.sh` (issue #212). Review the linked
release notes for breaking changes before merging.

| Action | From | To |
| --- | --- | --- |
| actions/cache | v5 | v6 |

### Upstream release notes

#### actions/cache v6

_Release notes not available; see https://github.com/actions/cache/releases_
