### PR TITLE
Bump external action references

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -28,7 +28,7 @@ jobs:
       with:
         persist-credentials: false
     - name: Set up Python
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@v7
       with:
         python-version: '3.x'
     - name: Install PyYAML

--- a/linters/bandit/action.yml
+++ b/linters/bandit/action.yml
@@ -37,7 +37,7 @@ runs:
 
     # https://github.com/marketplace/actions/setup-python
     - name: Setup Python
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@v7
       if: ${{ steps.check.outputs.continue == 'true' }}
       with:
         python-version: '3.x'

--- a/linters/eslint/action.yml
+++ b/linters/eslint/action.yml
@@ -41,7 +41,7 @@ runs:
 
     # https://github.com/marketplace/actions/setup-node-js-environment
     - name: Setup Node
-      uses: actions/setup-node@v6
+      uses: actions/setup-node@v7
       if: ${{ steps.check.outputs.continue == 'true' }}
       with:
         token: ${{ inputs.github-token }}

--- a/linters/markdownlint/action.yml
+++ b/linters/markdownlint/action.yml
@@ -56,7 +56,7 @@ runs:
 
     # https://github.com/marketplace/actions/setup-node-js-environment
     - name: Setup Node
-      uses: actions/setup-node@v6
+      uses: actions/setup-node@v7
       if: ${{ steps.check.outputs.continue == 'true' }}
       with:
         token: ${{ inputs.github-token }}

--- a/linters/semgrep/action.yml
+++ b/linters/semgrep/action.yml
@@ -37,7 +37,7 @@ runs:
 
     # https://github.com/marketplace/actions/setup-python
     - name: Setup Python
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@v7
       if: ${{ steps.check.outputs.continue == 'true' }}
       with:
         token: ${{ inputs.github-token }}

--- a/setup/action.yml
+++ b/setup/action.yml
@@ -587,7 +587,7 @@ runs:
 
     # https://github.com/marketplace/actions/setup-go-environment
     - name: Setup Go
-      uses: actions/setup-go@v6
+      uses: actions/setup-go@v7
       if: ${{ inputs.go-version != 'none' || steps.detect-versions.outputs.go-file }}
       with:
         go-version: ${{ inputs.go-version != 'none' && inputs.go-version || '' }}
@@ -657,7 +657,7 @@ runs:
 
     # https://github.com/marketplace/actions/setup-node-js-environment
     - name: Setup Node
-      uses: actions/setup-node@v6
+      uses: actions/setup-node@v7
       if: ${{ inputs.node-version != 'none' || steps.detect-versions.outputs.node-file }}
       with:
         node-version: ${{ inputs.node-version != 'none' && inputs.node-version || '' }}
@@ -704,7 +704,7 @@ runs:
 
     # https://github.com/marketplace/actions/setup-python
     - name: Setup Python
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@v7
       if: ${{ inputs.python-version != 'none' || steps.detect-versions.outputs.python-file }}
       with:
         python-version: ${{ inputs.python-version != 'none' && inputs.python-version || '' }}


### PR DESCRIPTION
## Automated external action bumps

Bumps external GitHub Action references to their latest upstream major/release.
Generated by `bump-actions/bump-actions.sh` (issue #212). Review the linked
release notes for breaking changes before merging.

| Action | From | To |
| --- | --- | --- |
| actions/setup-go | v6 | v7 |
| actions/setup-node | v6 | v7 |
| actions/setup-python | v6 | v7 |

### Upstream release notes

#### actions/setup-go v7

_Release notes not available; see https://github.com/actions/setup-go/releases_

#### actions/setup-node v7

_Release notes not available; see https://github.com/actions/setup-node/releases_

#### actions/setup-python v7

_Release notes not available; see https://github.com/actions/setup-python/releases_
