### PR TITLE
Bump Node version to 26.5.0 in build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ permissions:
   pull-requests: read
 env:
   NODE-CACHE: npm
-  NODE-VERSION: 26.4.0
+  NODE-VERSION: 26.5.0
 concurrency:
   group: build-${{github.ref}}
   cancel-in-progress: true


### PR DESCRIPTION
## Summary

Regenerates `.github/workflows/build.yml` to pick up the Node runtime bump defined upstream in `github-build` (`config/languages.yaml`), moving the workflow's `NODE-VERSION` from 26.4.0 to 26.5.0. This is a routine runtime refresh of the CI build; no action logic, inputs, or outputs change.

**Key changes:**

- `.github/workflows/build.yml`: `NODE-VERSION` bumped from `26.4.0` to `26.5.0`

## Types of changes

- [ ] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [x] Build or security update (updates dependencies, libraries, or security patches)
- [ ] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

- [ ] Unit tests added to validate my fix/feature
- [x] I have manually tested my change
- [x] I did not add automation test. Why ?: Version-only change to a generated workflow file; the existing action contract tests and the CI build itself validate it.
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] `readme.md` includes sections on introduction, installation, usage, and contributing
- [ ] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified
