### PR TITLE
Re-exec under bash 4+ so mapfile does not silently scan nothing

### DIFF
--- a/bump-actions/bump-actions.sh
+++ b/bump-actions/bump-actions.sh
@@ -228,5 +228,28 @@ function main()
 }
 
 if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  # `main` uses mapfile, a bash 4 builtin. `#!/usr/bin/env bash` resolves to the
+  # first bash on PATH, which on macOS is often Apple's 3.2 (/bin precedes
+  # /opt/homebrew/bin whenever /usr/libexec/path_helper runs after the shell
+  # profile). There mapfile fails, and with no `set -e` the scan carries on with
+  # an empty file list, prints "No YAML files to scan." and exits 0 -- a silent
+  # false negative rather than a crash. Re-exec under a newer bash instead.
+  #
+  # Only on direct execution: the test suite sources this file for the helpers
+  # above and must not be exec'd out from under bats.
+  if [ "${BASH_VERSINFO[0]}" -lt 4 ]; then
+    for candidate in /opt/homebrew/bin/bash /usr/local/bin/bash /usr/bin/bash; do
+      # shellcheck disable=SC2016
+      if [ -x "${candidate}" ] && [ "$("${candidate}" -c 'echo ${BASH_VERSINFO[0]}')" -ge 4 ]; then
+        # ${@+"${@}"} rather than "${@}": bash 3.2 treats the braced form as an
+        # unset variable under `set -u` when there are no positional parameters.
+        exec "${candidate}" "${0}" ${@+"${@}"}
+      fi
+    done
+
+    echo "::error::bump-actions.sh requires bash 4 or newer (running ${BASH_VERSION})" >&2
+    exit 1
+  fi
+
   main "$@"
 fi


### PR DESCRIPTION
# Summary

`bump-actions.sh` calls `mapfile` (bash 4.0+) at line 147, but its `#!/usr/bin/env bash` shebang resolves to the first `bash` on `PATH`. On macOS that is frequently Apple's `/bin/bash` 3.2, because `/usr/libexec/path_helper` re-promotes `/etc/paths` (`/usr/local/bin`, `/usr/bin`, `/bin`) to the front of `PATH` every time it runs — in `/etc/profile`, `/etc/zprofile`, and inside `brew shellenv`.

Unlike the other scripts in the org that hit this, `bump-actions.sh` has no `set -e`, so the failure is silent rather than loud. `mapfile` writes `command not found` to stderr, `files` stays empty, and the very next line reads that as "nothing to scan":

```
mapfile -t files < <(target_files)
if [ "${#files[@]}" -eq 0 ]; then
  echo "No YAML files to scan." >&2
  return 0
fi
```

Measured on macOS before this change: **exit 0 after scanning 0 of 34 YAML files**. In `--apply` mode that is a clean "no bumps available" for a repo that may well have bumps — a false negative that looks like a successful run. It also made 7 of the 19 `bump-actions` bats tests fail locally (6, 12, 14, 16, 17 and two others); all 19 pass now.

The weekly cron in `external-actions-bump.yml` and the bats job in `build.yml` both run on `ubuntu-latest` today, so CI is unaffected. The exposure is developers running the documented dry-run by hand on a Mac, and any future move to a macOS runner — `build.yml` already carries a `$RUNNER_OS == "macOS"` branch that installs `bats-core` via brew.

**Key changes:**

- `bump-actions/bump-actions.sh`: re-exec under the first bash 4+ found at `/opt/homebrew/bin/bash`, `/usr/local/bin/bash` or `/usr/bin/bash`, emitting a `::error::` annotation and exiting 1 when none exists
- The guard sits inside the existing `[[ "${BASH_SOURCE[0]}" == "${0}" ]]` block, so sourcing the file for helper unit tests never execs bats out from under itself
- Arguments pass through as `${@+"${@}"}` — bash 3.2 treats the braced `"${@}"` as an unset variable under `set -u` when there are no positional parameters

## Types of changes

- [x] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [ ] Build or security update (updates dependencies, libraries, or security patches)
- [ ] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

- [ ] Unit tests added to validate my fix/feature
- [x] I have manually tested my change
- [x] I did not add automation test. Why ?: the existing 19-test bats suite already covers this path; it was failing 7 tests locally on macOS and is green after the fix. Asserting on the interpreter version would test the harness, not the script.
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] `readme.md` includes sections on introduction, installation, usage, and contributing
- [ ] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified
