### PR TITLE
Document bash 4+ re-exec guard for bump-actions in architecture docs

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -108,7 +108,11 @@ upstream version. Powers the weekly external-actions bump cron (issue #212).
 
 **Invocation:** Run out of band by `.github/workflows/external-actions-bump.yml`
 (weekly cron); unit-tested via `bump-actions/tests/bump-actions.bats`. Requires
-an authenticated `gh` on PATH.
+an authenticated `gh` on PATH and bash 4 or newer: `main` uses `mapfile`, so on
+direct execution the script re-execs under the first bash 4+ found in
+`/opt/homebrew/bin`, `/usr/local/bin` or `/usr/bin` (and fails loudly if none
+exists) rather than silently scanning an empty file list under macOS bash 3.2.
+The guard is skipped when the file is sourced, so the bats suite is unaffected.
 
 ### cis
 


### PR DESCRIPTION
## Summary

Follow-up documentation for the bash 4+ re-exec guard added to `bump-actions` in #268. The architecture reference previously listed only "an authenticated `gh` on PATH" as an invocation requirement, which understated the runtime constraint: `main` relies on `mapfile`, a bash 4 builtin that is absent from the macOS system bash 3.2. Without documenting the guard, a reader has no way to know why the script re-execs itself or why sourcing it behaves differently from running it.

**Key changes:**

- `docs/architecture.md`: expand the `bump-actions` **Invocation** paragraph to state the bash 4-or-newer requirement alongside the existing `gh` requirement
- Describe the re-exec behavior on direct execution — the script searches `/opt/homebrew/bin`, `/usr/local/bin` and `/usr/bin` for the first bash 4+ and fails loudly when none is found, instead of silently scanning an empty file list under bash 3.2
- Note that the guard is skipped when the file is sourced, so the `bump-actions/tests/bump-actions.bats` suite is unaffected

## Types of changes

- [ ] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [ ] Build or security update (updates dependencies, libraries, or security patches)
- [x] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

- [ ] Unit tests added to validate my fix/feature
- [x] I have manually tested my change
- [x] I did not add automation test. Why ?: Documentation-only change; the behavior it describes is already covered by `bump-actions/tests/bump-actions.bats`
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] `readme.md` includes sections on introduction, installation, usage, and contributing
- [x] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified
