### PR TITLE
#263: regenerate build.yml with npm caching wired to slack/package-lock.json

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -200,6 +200,8 @@ jobs:
         ssh-key: "${{secrets.SSH_KEY}}"
         github-token: "${{secrets.GH_PAT}}"
         node-version: "${{env.NODE-VERSION}}"
+        node-cache: "${{env.NODE-CACHE}}"
+        node-cache-dependency-path: slack/package-lock.json
     - name: NPM (slack)
       shell: bash
       run: cd slack && npm ci


### PR DESCRIPTION
# Summary

Regenerates `.github/workflows/build.yml` so the JavaScript Unit Tests job actually uses the npm cache that `NODE-CACHE: npm` has been advertising since the env var was introduced. Until now the Setup step passed only `node-version`, `actions/setup-node` received an empty `cache:`, and every run re-downloaded the `slack/` npm dependencies.

The fix itself is in the generator — Cloud-Officer/github-build#490. This PR is only the regenerated output; `build.yml` is generated by github-build and is never hand-edited.

⚠️ **Merge order:** this PR must merge **after** Cloud-Officer/github-build#490. Regenerating against the current generator would drop these two lines again.

**Key changes:**

- `.github/workflows/build.yml`: the `js_unit_tests` Setup step gains `node-cache: "${{env.NODE-CACHE}}"` and `node-cache-dependency-path: slack/package-lock.json`

That is the entire diff — two added lines, nothing else in the file changed.

The dependency path matters as much as the cache flag: this repo has no root `package-lock.json`, so a bare `cache: npm` would make `actions/setup-node` fail the job with "Dependencies lock file is not found". The generator now derives both together from the lockfiles it actually detects.

Regenerated with the repo's recorded invocation (`--organization Cloud-Officer --skip_license_check --skip_slack`), plus `--skip_repository_settings` and `--no_strict_version_check` locally so the run touched neither the repository's remote settings nor the unrelated `NODE-VERSION` 26.5.0 → 26.5.1 bump the config now recommends. That bump is left for a separate PR.

Closes #263

## Types of changes

- [x] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [ ] Build or security update (updates dependencies, libraries, or security patches)
- [ ] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

- [ ] Unit tests added to validate my fix/feature
- [x] I have manually tested my change
- [x] I did not add automation test. Why ?: `build.yml` is a generated file with no unit-testable logic of its own. The generator change behind it is covered by 8 new RSpec examples in Cloud-Officer/github-build#490, including one asserting the sub-project lockfile path this repo depends on. `tests/action_contracts.py`, `actionlint` and `yamllint` all pass on the regenerated file.
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] `readme.md` includes sections on introduction, installation, usage, and contributing
- [ ] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified

## Further comments (if required)

No breaking change, but the first run after merge is the one to watch: if the cache key or the dependency path were wrong, `actions/setup-node` fails the JavaScript Unit Tests job outright rather than silently skipping the cache. Confirm the job log shows a cache restore/save for npm and that the job passes.
