### PR TITLE
Bump external action references

### DIFF
--- a/setup/action.yml
+++ b/setup/action.yml
@@ -752,7 +752,7 @@ runs:
 
     # https://github.com/marketplace/actions/setup-android-sdk-for-self-hosted-runner
     - name: Setup Android
-      uses: amyu/setup-android@v5
+      uses: amyu/setup-android@v6.0
       if: ${{ inputs.android-sdk-version != 'none'}}
       with:
         sdk-version: ${{ inputs.android-sdk-version }}


### PR DESCRIPTION
## Automated external action bumps

Bumps external GitHub Action references to their latest upstream major/release.
Generated by `bump-actions/bump-actions.sh` (issue #212). Review the linked
release notes for breaking changes before merging.

| Action | From | To |
| --- | --- | --- |
| amyu/setup-android | v5 | v6.0 |

### Upstream release notes

#### amyu/setup-android v6.0

## Highlights

- **About 23% smaller action bundles.** Compared with v5.7, the setup bundle decreased from 2.73 MB to 2.10 MB, and the post-job cleanup bundle decreased from 2.77 MB to 2.13 MB.
- **Updated Android defaults.** When inputs are omitted, the action now installs Android SDK 37.0 and command-line tools 15859902.
- **Improved macOS support.** Command-line tools 15859902 and later automatically use the correct archive for Apple Silicon or Intel runners.
- **Correct side-by-side NDK path.** When `ndk-version` is specified, `$ANDROID_SDK_ROOT/ndk/<version>` is added to `PATH` instead of the legacy `ndk-bundle` directory.

## Upgrade notes

- Reference the exact release tag, such as `amyu/setup-android@v6.0`, or pin the full commit SHA. Starting with v6, a floating `v6` tag is not published or maintained.
- v6 uses a separate cache namespace from v5, so the first v6 run will rebuild the Android SDK cache.
- If your workflow relies on default inputs, review the new SDK and command-line tools versions above before upgrading.

## What's Changed
* Use English for repository-facing content by @amyu in https://github.com/amyu/setup-android/pull/786
* docs: update README for v5.7 by @github-actions[bot] in https://github.com/amyu/setup-android/pull/785
* chore(deps): update actions/setup-node action to v6.5.0 by @renovate[bot] in https://github.com/amyu/setup-android/pull/787
* chore(deps): update actions/setup-node action to v7 by @renovate[bot] in https://github.com/amyu/setup-android/pull/788
* chore(deps): update android gradle plugin to v9.3.0 by @renovate[bot] in https://github.com/amyu/setup-android/pull/789
* Group Biome updates into one Renovate PR by @amyu in https://github.com/amyu/setup-android/pull/792
* chore(deps): update dependency @biomejs/biome to v2.5.4 by @renovate[bot] in https://github.com/amyu/setup-android/pull/790
* chore(deps): update dependency @biomejs/biome to v2.5.4 - autoclosed by @renovate[bot] in https://github.com/amyu/setup-android/pull/791
* chore(deps): update biome by @renovate[bot] in https://github.com/amyu/setup-android/pull/793
* chore(deps): update pnpm to v11.13.1 by @renovate[bot] in https://github.com/amyu/setup-android/pull/794
* chore(deps): update actions/setup-java action to v5.6.0 by @renovate[bot] in https://github.com/amyu/setup-android/pull/795
* chore(deps): update pnpm to v11.15.0 by @renovate[bot] in https://github.com/amyu/setup-android/pull/796
* chore(deps): update pnpm to v11.15.1 by @renovate[bot] in https://github.com/amyu/setup-android/pull/798
* chore(deps): update actions/checkout action to v7.0.1 by @renovate[bot] in https://github.com/amyu/setup-android/pull/799
* Update command-line-tools version to 15859902 by @github-actions[bot] in https://github.com/amyu/setup-android/pull/797
* chore(deps): update actions/checkout action to v7.0.1 by @renovate[bot] in https://github.com/amyu/setup-android/pull/802
* Pin npm dependency versions by @amyu in https://github.com/amyu/setup-android/pull/801
* chore(deps): update actions/setup-node action to v7 by @renovate[bot] in https://github.com/amyu/setup-android/pull/805
* chore(deps): update pnpm to v11.16.0 by @renovate[bot] in https://github.com/amyu/setup-android/pull/806
* Keep Node.js runtime versions in sync by @amyu in https://github.com/amyu/setup-android/pull/807
* chore(deps): update android gradle plugin to v9.3.1 by @renovate[bot] in https://github.com/amyu/setup-android/pull/809
* chore(deps): update pnpm to v11.17.0 by @renovate[bot] in https://github.com/amyu/setup-android/pull/810
* chore(deps): update node.js to v24.18.1 by @renovate[bot] in https://github.com/amyu/setup-android/pull/808
* Migrate linting and formatting to Oxc by @amyu in https://github.com/amyu/setup-android/pull/812
* Migrate bundling from Rollup to Rolldown by @amyu in https://github.com/amyu/setup-android/pull/811
* Prepare v6 release by @amyu in https://github.com/amyu/setup-android/pull/813
